### PR TITLE
Fix clogged pump jack high idle power consumption

### DIFF
--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/PumpjackTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/PumpjackTileEntity.java
@@ -184,7 +184,6 @@ public class PumpjackTileEntity extends PoweredMultiblockTileEntity<PumpjackTile
 				if(available > 0 || residual > 0){
 					int oilAmnt = getFluidAmount() <= 0 ? residual : getFluidAmount();
 					
-					this.energyStorage.extractEnergy(consumption, false);
 					FluidStack out = new FluidStack(getFluidType(), Math.min(IPServerConfig.EXTRACTION.pumpjack_speed.get(), oilAmnt));
 					Direction facing = getIsMirrored() ? getFacing().rotateYCCW() : getFacing().rotateY();
 					BlockPos outputPos = master().getBlockPosForPos(East_Port).offset(facing);
@@ -210,7 +209,10 @@ public class PumpjackTileEntity extends PoweredMultiblockTileEntity<PumpjackTile
 							active = true;
 						}
 					}
-					
+					if(active)
+					{
+						this.energyStorage.extractEnergy(consumption, false);
+					}
 					this.activeTicks++;
 				}
 			}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/PumpjackTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/PumpjackTileEntity.java
@@ -209,8 +209,8 @@ public class PumpjackTileEntity extends PoweredMultiblockTileEntity<PumpjackTile
 							active = true;
 						}
 					}
-					if(active)
-					{
+					
+					if(active){
 						this.energyStorage.extractEnergy(consumption, false);
 					}
 					this.activeTicks++;


### PR DESCRIPTION
When the pump jack can't output its fluid to an already filled fluid tank it stops working as intended. However it still consumes ~1024 flux/tick while doing nothing. This prevents the pump jack from consuming power by using the boolean "active" that gets only set true once adjacent fluid containers accepted some amount of fluid greater than zero.