### PR TITLE
Update IE dependency and fix compile errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,9 +107,9 @@ minecraft {
 dependencies {
 	minecraft "net.minecraftforge:forge:1.16.5-36.2.0"
 	
-	compile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.3-138")
+	compile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.4-139")
 	//compile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.0-135:api")
-	datagenCompile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.3-138:datagen")
+	datagenCompile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.4-139:datagen")
 	
 	compile fg.deobf(group: "com.blamejared.crafttweaker", name: "CraftTweaker-1.16.5", version: "7.1.0.103")
 	

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,8 @@ minecraft {
 			property 'forge.logging.markers', ''
 			property 'forge.logging.console.level', 'info'
 			property 'fml.earlyprogresswindow', 'false'
-			property 'mixin.env.disableRefMap', 'true'
+			property 'mixin.env.remapRefMap', 'true'
+			property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 			mods {
 				immersivepetroleum {
 					source sourceSets.main
@@ -66,7 +67,8 @@ minecraft {
 			property 'forge.logging.markers', ''
 			property 'forge.logging.console.level', 'info'
 			property 'fml.earlyprogresswindow', 'false'
-			property 'mixin.env.disableRefMap', 'true'
+			property 'mixin.env.remapRefMap', 'true'
+			property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 			
 			arg '-nogui'
 			
@@ -82,7 +84,8 @@ minecraft {
 			property 'forge.logging.markers', ''
 			property 'forge.logging.console.level', 'info'
 			property 'fml.earlyprogresswindow', 'false'
-			property 'mixin.env.disableRefMap', 'true'
+			property 'mixin.env.remapRefMap', 'true'
+			property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
 			
 			args '--mod', 'immersivepetroleum',
 				 '--all',

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/IPMetalMultiblock.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/IPMetalMultiblock.java
@@ -16,8 +16,8 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.ResourceLocation;
 
 public class IPMetalMultiblock<T extends MultiblockPartTileEntity<T>> extends MetalMultiblockBlock<T>{
-	public IPMetalMultiblock(String name, Supplier<TileEntityType<T>> te, Property<?>... additionalProperties){
-		super(name, te, additionalProperties);
+	public IPMetalMultiblock(String name, Supplier<TileEntityType<T>> te){
+		super(name, te);
 		
 		// Nessesary hacks
 		IEContent.registeredIEBlocks.remove(this);

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/CokerUnitTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/CokerUnitTileEntity.java
@@ -191,7 +191,7 @@ public class CokerUnitTileEntity extends PoweredMultiblockTileEntity<CokerUnitTi
 	}
 	
 	@Override
-	public void doGraphicalUpdates(int slot){
+	public void doGraphicalUpdates(){
 		updateMasterBlock(null, true);
 	}
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/DistillationTowerTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/DistillationTowerTileEntity.java
@@ -320,7 +320,7 @@ public class DistillationTowerTileEntity extends PoweredMultiblockTileEntity<Dis
 	}
 	
 	@Override
-	public void doGraphicalUpdates(int slot){
+	public void doGraphicalUpdates(){
 		updateMasterBlock(null, true);
 	}
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/HydrotreaterTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/HydrotreaterTileEntity.java
@@ -115,7 +115,7 @@ public class HydrotreaterTileEntity extends PoweredMultiblockTileEntity<Hydrotre
 	}
 	
 	@Override
-	public void doGraphicalUpdates(int slot){
+	public void doGraphicalUpdates(){
 		this.markDirty();
 		this.markContainingBlockForUpdate(null);
 	}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/PumpjackTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/PumpjackTileEntity.java
@@ -303,7 +303,7 @@ public class PumpjackTileEntity extends PoweredMultiblockTileEntity<PumpjackTile
 	}
 	
 	@Override
-	public void doGraphicalUpdates(int slot){
+	public void doGraphicalUpdates(){
 		this.markDirty();
 		this.markContainingBlockForUpdate(null);
 	}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/items/MotorboatItem.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/items/MotorboatItem.java
@@ -204,13 +204,12 @@ public class MotorboatItem extends IPItemBase implements IUpgradeableTool{
 	}
 	
 	@Override
-	public Slot[] getWorkbenchSlots(Container container, ItemStack stack, Supplier<World> getWorld, Supplier<PlayerEntity> getPlayer){
-		IItemHandler inv = stack.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).orElse(null);
+	public Slot[] getWorkbenchSlots(Container container, ItemStack stack, World world, Supplier<PlayerEntity> getPlayer, IItemHandler inv){
 		if(inv != null){
 			return new Slot[]{
-					new IESlot.Upgrades(container, inv, 0, 78, 35 - 5, UPGRADE_TYPE, stack, true, getWorld, getPlayer),
-					new IESlot.Upgrades(container, inv, 1, 98, 35 + 5, UPGRADE_TYPE, stack, true, getWorld, getPlayer),
-					new IESlot.Upgrades(container, inv, 2, 118, 35 - 5, UPGRADE_TYPE, stack, true, getWorld, getPlayer)
+					new IESlot.Upgrades(container, inv, 0, 78, 35 - 5, UPGRADE_TYPE, stack, true, world, getPlayer),
+					new IESlot.Upgrades(container, inv, 1, 98, 35 + 5, UPGRADE_TYPE, stack, true, world, getPlayer),
+					new IESlot.Upgrades(container, inv, 2, 118, 35 - 5, UPGRADE_TYPE, stack, true, world, getPlayer)
 			};
 		}else{
 			return new Slot[0];

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -17,7 +17,7 @@ license="All rights reserved"
 [[dependencies.immersivepetroleum]]
 	modId="immersiveengineering"
 	mandatory=true
-	versionRange="[1.16.5-5.0.0,)"
+	versionRange="[1.16.5-5.0.4,)"
 	ordering="BEFORE"
 	side="BOTH"
 


### PR DESCRIPTION
The change to how Mixin refmaps are handled is necessary since IE uses completly different mappings from IP now.