### PR TITLE
Update methods for IE 5.0.4.319

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,9 +104,9 @@ minecraft {
 dependencies {
 	minecraft "net.minecraftforge:forge:1.16.5-36.2.0"
 	
-	compile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.3-138")
+	compile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.4-139")
 	//compile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.0-135:api")
-	datagenCompile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.3-138:datagen")
+	datagenCompile fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.5-5.0.4-139:datagen")
 	
 	compile fg.deobf(group: "com.blamejared.crafttweaker", name: "CraftTweaker-1.16.5", version: "7.1.0.103")
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/IPMetalMultiblock.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/IPMetalMultiblock.java
@@ -16,8 +16,8 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.ResourceLocation;
 
 public class IPMetalMultiblock<T extends MultiblockPartTileEntity<T>> extends MetalMultiblockBlock<T>{
-	public IPMetalMultiblock(String name, Supplier<TileEntityType<T>> te, Property<?>... additionalProperties){
-		super(name, te, additionalProperties);
+	public IPMetalMultiblock(String name, Supplier<TileEntityType<T>> te){
+		super(name, te);
 		
 		// Nessesary hacks
 		IEContent.registeredIEBlocks.remove(this);

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/CokerUnitTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/CokerUnitTileEntity.java
@@ -191,7 +191,7 @@ public class CokerUnitTileEntity extends PoweredMultiblockTileEntity<CokerUnitTi
 	}
 	
 	@Override
-	public void doGraphicalUpdates(int slot){
+	public void doGraphicalUpdates(){
 		updateMasterBlock(null, true);
 	}
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/DistillationTowerTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/DistillationTowerTileEntity.java
@@ -320,7 +320,7 @@ public class DistillationTowerTileEntity extends PoweredMultiblockTileEntity<Dis
 	}
 	
 	@Override
-	public void doGraphicalUpdates(int slot){
+	public void doGraphicalUpdates(){
 		updateMasterBlock(null, true);
 	}
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/HydrotreaterTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/HydrotreaterTileEntity.java
@@ -115,7 +115,7 @@ public class HydrotreaterTileEntity extends PoweredMultiblockTileEntity<Hydrotre
 	}
 	
 	@Override
-	public void doGraphicalUpdates(int slot){
+	public void doGraphicalUpdates(){
 		this.markDirty();
 		this.markContainingBlockForUpdate(null);
 	}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/PumpjackTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/PumpjackTileEntity.java
@@ -303,7 +303,7 @@ public class PumpjackTileEntity extends PoweredMultiblockTileEntity<PumpjackTile
 	}
 	
 	@Override
-	public void doGraphicalUpdates(int slot){
+	public void doGraphicalUpdates(){
 		this.markDirty();
 		this.markContainingBlockForUpdate(null);
 	}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/items/MotorboatItem.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/items/MotorboatItem.java
@@ -202,9 +202,9 @@ public class MotorboatItem extends IPItemBase implements IUpgradeableTool{
 	@Override
 	public void finishUpgradeRecalculation(ItemStack stack){
 	}
-	
+
 	@Override
-	public Slot[] getWorkbenchSlots(Container container, ItemStack stack, Supplier<World> getWorld, Supplier<PlayerEntity> getPlayer){
+	public Slot[] getWorkbenchSlots(Container container, ItemStack stack, World getWorld, Supplier<PlayerEntity> getPlayer, IItemHandler toolInventory) {
 		IItemHandler inv = stack.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).orElse(null);
 		if(inv != null){
 			return new Slot[]{
@@ -216,7 +216,7 @@ public class MotorboatItem extends IPItemBase implements IUpgradeableTool{
 			return new Slot[0];
 		}
 	}
-	
+
 	@OnlyIn(Dist.CLIENT)
 	@Override
 	public void addInformation(ItemStack stack, World worldIn, List<ITextComponent> tooltip, ITooltipFlag flagIn){


### PR DESCRIPTION
Update methods for newest version of IE (5.0.4-319) to allow passing builds.

This should also fix #55.