### PR TITLE
Hydrotreater tick order change & Lubricate event changes

### DIFF
--- a/src/main/java/flaxbeard/immersivepetroleum/api/crafting/LubricatedHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/api/crafting/LubricatedHandler.java
@@ -46,6 +46,8 @@ public class LubricatedHandler{
 		
 		void lubricate(World world, int ticks, E mbte);
 		
+		void lubricate(World world, int ticks, E mbte, AutoLubricatorTileEntity lubricator);
+		
 		@OnlyIn(Dist.CLIENT)
 		void renderPipes(AutoLubricatorTileEntity lubricator, E mbte, MatrixStack matrix, IRenderTypeBuffer buffer, int combinedLight, int combinedOverlay);
 		

--- a/src/main/java/flaxbeard/immersivepetroleum/api/crafting/LubricatedHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/api/crafting/LubricatedHandler.java
@@ -33,6 +33,7 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fluids.FluidStack;
 
 public class LubricatedHandler{
 	public interface ILubricationHandler<E extends TileEntity> {
@@ -46,7 +47,7 @@ public class LubricatedHandler{
 		
 		void lubricate(World world, int ticks, E mbte);
 		
-		void lubricate(World world, int ticks, E mbte, AutoLubricatorTileEntity lubricator);
+		void lubricate(World world, int ticks, E mbte, FluidStack lubrication);
 		
 		@OnlyIn(Dist.CLIENT)
 		void renderPipes(AutoLubricatorTileEntity lubricator, E mbte, MatrixStack matrix, IRenderTypeBuffer buffer, int combinedLight, int combinedOverlay);

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/AutoLubricatorTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/AutoLubricatorTileEntity.java
@@ -242,7 +242,7 @@ public class AutoLubricatorTileEntity extends IPTileEntityBase implements ITicka
 					TileEntity master = handler.isPlacedCorrectly(this.world, this, this.facing);
 					if(master != null && handler.isMachineEnabled(this.world, master)){
 						this.count++;
-						handler.lubricate(this.world, this.count, master);
+						handler.lubricate(this.world, this.count, master, this.tank.getFluid());
 						
 						if(!this.world.isRemote && this.count % 4 == 0){
 							this.tank.drain(LubricantHandler.getLubeAmount(this.tank.getFluid().getFluid()), FluidAction.EXECUTE);

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/HydrotreaterTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/HydrotreaterTileEntity.java
@@ -213,7 +213,6 @@ public class HydrotreaterTileEntity extends PoweredMultiblockTileEntity<Hydrotre
 	@Override
 	public void tick(){
 		super.tick();
-		checkForNeedlessTicking();
 		
 		if(this.world.isRemote || isDummy() || isRSDisabled()){
 			return;

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/HydrotreaterTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/HydrotreaterTileEntity.java
@@ -212,6 +212,7 @@ public class HydrotreaterTileEntity extends PoweredMultiblockTileEntity<Hydrotre
 	
 	@Override
 	public void tick(){
+		super.tick();
 		checkForNeedlessTicking();
 		
 		if(this.world.isRemote || isDummy() || isRSDisabled()){
@@ -252,7 +253,6 @@ public class HydrotreaterTileEntity extends PoweredMultiblockTileEntity<Hydrotre
 			update = true;
 		}
 		
-		super.tick();
 		
 		if(this.tanks[TANK_OUTPUT].getFluidAmount() > 0){
 			BlockPos outPos = getBlockPosForPos(Fluid_OUT).up();

--- a/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/CrusherLubricationHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/CrusherLubricationHandler.java
@@ -63,6 +63,11 @@ public class CrusherLubricationHandler implements ILubricationHandler<CrusherTil
 	
 	@Override
 	public void lubricate(World world, int ticks, CrusherTileEntity mbte){
+		lubricate(world, ticks, mbte, null);
+	}
+	
+	@Override
+	public void lubricate(World world, int ticks, CrusherTileEntity mbte, AutoLubricatorTileEntity lubricator){
 		if(!world.isRemote){
 			Iterator<MultiblockProcess<CrusherRecipe>> processIterator = mbte.processQueue.iterator();
 			MultiblockProcess<CrusherRecipe> process = processIterator.next();

--- a/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/CrusherLubricationHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/CrusherLubricationHandler.java
@@ -31,6 +31,7 @@ import net.minecraft.util.math.vector.Vector3i;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fluids.FluidStack;
 
 public class CrusherLubricationHandler implements ILubricationHandler<CrusherTileEntity>{
 	private static Vector3i size = new Vector3i(3, 3, 5);
@@ -67,7 +68,7 @@ public class CrusherLubricationHandler implements ILubricationHandler<CrusherTil
 	}
 	
 	@Override
-	public void lubricate(World world, int ticks, CrusherTileEntity mbte, AutoLubricatorTileEntity lubricator){
+	public void lubricate(World world, int ticks, CrusherTileEntity mbte, FluidStack lubrication){
 		if(!world.isRemote){
 			Iterator<MultiblockProcess<CrusherRecipe>> processIterator = mbte.processQueue.iterator();
 			MultiblockProcess<CrusherRecipe> process = processIterator.next();

--- a/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/ExcavatorLubricationHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/ExcavatorLubricationHandler.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import com.mojang.blaze3d.matrix.MatrixStack;
 
 import blusunrize.immersiveengineering.common.blocks.metal.BucketWheelTileEntity;
+import blusunrize.immersiveengineering.common.blocks.metal.CrusherTileEntity;
 import blusunrize.immersiveengineering.common.blocks.metal.ExcavatorTileEntity;
 import blusunrize.immersiveengineering.common.config.IEServerConfig;
 import flaxbeard.immersivepetroleum.ImmersivePetroleum;
@@ -77,6 +78,11 @@ public class ExcavatorLubricationHandler implements ILubricationHandler<Excavato
 	
 	@Override
 	public void lubricate(World world, int ticks, ExcavatorTileEntity mbte){
+		lubricate(world, ticks, mbte, null);
+	}
+	
+	@Override
+	public void lubricate(World world, int ticks, ExcavatorTileEntity mbte, AutoLubricatorTileEntity lubricator){
 		BlockPos wheelPos = mbte.getWheelCenterPos();
 		TileEntity center = world.getTileEntity(wheelPos);
 		

--- a/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/ExcavatorLubricationHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/ExcavatorLubricationHandler.java
@@ -5,7 +5,6 @@ import java.util.function.Supplier;
 import com.mojang.blaze3d.matrix.MatrixStack;
 
 import blusunrize.immersiveengineering.common.blocks.metal.BucketWheelTileEntity;
-import blusunrize.immersiveengineering.common.blocks.metal.CrusherTileEntity;
 import blusunrize.immersiveengineering.common.blocks.metal.ExcavatorTileEntity;
 import blusunrize.immersiveengineering.common.config.IEServerConfig;
 import flaxbeard.immersivepetroleum.ImmersivePetroleum;
@@ -31,6 +30,7 @@ import net.minecraft.util.math.vector.Vector3i;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fluids.FluidStack;
 
 public class ExcavatorLubricationHandler implements ILubricationHandler<ExcavatorTileEntity>{
 	private static Vector3i size = new Vector3i(3, 6, 3);
@@ -82,7 +82,7 @@ public class ExcavatorLubricationHandler implements ILubricationHandler<Excavato
 	}
 	
 	@Override
-	public void lubricate(World world, int ticks, ExcavatorTileEntity mbte, AutoLubricatorTileEntity lubricator){
+	public void lubricate(World world, int ticks, ExcavatorTileEntity mbte, FluidStack lubrication){
 		BlockPos wheelPos = mbte.getWheelCenterPos();
 		TileEntity center = world.getTileEntity(wheelPos);
 		

--- a/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/PumpjackLubricationHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/PumpjackLubricationHandler.java
@@ -58,7 +58,12 @@ public class PumpjackLubricationHandler implements ILubricationHandler<PumpjackT
 	}
 	
 	@Override
-	public void lubricate(World world, int ticks, PumpjackTileEntity mbte){
+	public void lubricate(World world, int ticks, PumpjackTileEntity mbte) {
+		lubricate(world, ticks, mbte, null);
+	}
+	
+	@Override
+	public void lubricate(World world, int ticks, PumpjackTileEntity mbte, AutoLubricatorTileEntity lubricator){
 		if(!world.isRemote){
 			if(ticks % 4 == 0){
 				mbte.tick();

--- a/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/PumpjackLubricationHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/lubehandlers/PumpjackLubricationHandler.java
@@ -25,6 +25,7 @@ import net.minecraft.util.math.vector.Vector3i;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fluids.FluidStack;
 
 public class PumpjackLubricationHandler implements ILubricationHandler<PumpjackTileEntity>{
 	private static Vector3i size = new Vector3i(4, 6, 3);
@@ -63,7 +64,7 @@ public class PumpjackLubricationHandler implements ILubricationHandler<PumpjackT
 	}
 	
 	@Override
-	public void lubricate(World world, int ticks, PumpjackTileEntity mbte, AutoLubricatorTileEntity lubricator){
+	public void lubricate(World world, int ticks, PumpjackTileEntity mbte, FluidStack lubrication){
 		if(!world.isRemote){
 			if(ticks % 4 == 0){
 				mbte.tick();


### PR DESCRIPTION
Change to the sulfur recovery unit TileEntity to run super.tick() to clear the processing queue before doing the rest of the tick. Also includes the AutoLubricatorTileEntity as a parameter in the lubricate event for Lubrication handlers, as well as adds a version without it to act as a facade.

Resubmit of #86 without delimiter changes