### PR TITLE
Update Spill Particles to be Dependent Upon Flow

### DIFF
--- a/src/main/java/flaxbeard/immersivepetroleum/client/ClientProxy.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/client/ClientProxy.java
@@ -33,6 +33,7 @@ import flaxbeard.immersivepetroleum.client.gui.CokerUnitScreen;
 import flaxbeard.immersivepetroleum.client.gui.DerrickScreen;
 import flaxbeard.immersivepetroleum.client.gui.DistillationTowerScreen;
 import flaxbeard.immersivepetroleum.client.gui.HydrotreaterScreen;
+import flaxbeard.immersivepetroleum.client.particle.FluidParticleData;
 import flaxbeard.immersivepetroleum.client.render.SeismicResultRenderer;
 import flaxbeard.immersivepetroleum.client.render.debugging.DebugRenderHandler;
 import flaxbeard.immersivepetroleum.client.utils.MCUtil;
@@ -61,6 +62,7 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
@@ -75,6 +77,9 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.ClientRegistry;
 import net.minecraftforge.client.model.data.EmptyModelData;
 import net.minecraftforge.client.settings.KeyConflictContext;
@@ -202,6 +207,28 @@ public class ClientProxy extends CommonProxy{
 		transform.translate(0.0F, 0.5F, 1.0F);
 		blockRenderer.getModelRenderer().renderModel(transform.last(), buffers.getBuffer(RenderType.solid()), state, model, 1.0F, 1.0F, 1.0F, -1, -1, EmptyModelData.INSTANCE);
 		transform.popPose();
+	}
+	
+	@OnlyIn(Dist.CLIENT)
+	public static void spawnSpillParticles(Level world, BlockPos pos, Fluid fluid, int particles, float yOffset, float speed){
+		if(fluid == null || fluid == Fluids.EMPTY){
+			return;
+		}
+		
+		for(int i = 0;i < particles;i++){
+			float xa = (world.random.nextFloat() - .5F) / 2F;
+			float ya = 0.25F + (0.5F + (world.random.nextFloat() * 0.25F)) * speed;
+			float za = (world.random.nextFloat() - .5F) / 2F;
+			
+			float rx = (world.random.nextFloat() - .5F) * 0.5F;
+			float rz = (world.random.nextFloat() - .5F) * 0.5F;
+			
+			double x = (pos.getX() + 0.5) + rx;
+			double y = (pos.getY() + yOffset);
+			double z = (pos.getZ() + 0.5) + rz;
+			
+			world.addParticle(new FluidParticleData(fluid), x, y, z, xa, ya, za);
+		}
 	}
 	
 	@Override

--- a/src/main/java/flaxbeard/immersivepetroleum/client/ClientProxy.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/client/ClientProxy.java
@@ -210,14 +210,14 @@ public class ClientProxy extends CommonProxy{
 	}
 	
 	@OnlyIn(Dist.CLIENT)
-	public static void spawnSpillParticles(Level world, BlockPos pos, Fluid fluid, int particles, float yOffset, float speed){
+	public static void spawnSpillParticles(Level world, BlockPos pos, Fluid fluid, int particles, float yOffset, float flow){
 		if(fluid == null || fluid == Fluids.EMPTY){
 			return;
 		}
 		
 		for(int i = 0;i < particles;i++){
 			float xa = (world.random.nextFloat() - .5F) / 2F;
-			float ya = 0.25F + (0.5F + (world.random.nextFloat() * 0.25F)) * speed;
+			float ya = 0.25F + (0.5F + (world.random.nextFloat() * 0.25F)) * flow/800;
 			float za = (world.random.nextFloat() - .5F) / 2F;
 			
 			float rx = (world.random.nextFloat() - .5F) * 0.5F;

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/DerrickTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/DerrickTileEntity.java
@@ -105,7 +105,7 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 	
 	public final NonNullList<ItemStack> inventory = NonNullList.withSize(1, ItemStack.EMPTY);
 	public boolean drilling, spilling;
-	public int clientFlow;
+	private int clientFlow;
 	public int timer = 0;
 	
 	private Fluid fluidSpilled = Fluids.EMPTY;
@@ -154,8 +154,7 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 		nbt.putInt("timer", this.timer);
 		
 		nbt.putString("spillingfluid", this.fluidSpilled.getRegistryName().toString());
-		nbt.putInt("flow", ReservoirHandler.getIsland(getLevelNonnull(), getBlockPos()) == null || this.worldPosition.getY() < getLevelNonnull().getSeaLevel() ? 10 :
-			ReservoirIsland.getFlow(ReservoirHandler.getIsland(getLevelNonnull(), getBlockPos()).getPressure(getLevelNonnull(), getBlockPos().getX(), getBlockPos().getZ())));
+		nbt.putInt("flow", getReservoirFlow());
 		
 		nbt.put("tank", this.tank.writeToNBT(new CompoundTag()));
 		
@@ -231,7 +230,7 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 		}
 		
 		if(this.spilling){
-			ClientProxy.spawnSpillParticles(level, this.worldPosition, this.fluidSpilled, 5, 15.75F, clientFlow/450f);
+			ClientProxy.spawnSpillParticles(level, this.worldPosition, this.fluidSpilled, 5, 15.75F, clientFlow);
 		}
 	}
 	
@@ -346,7 +345,7 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 				if(well != null && well.wellPipeLength == well.getMaxPipeLength()) outputReservoirFluid();
 			}
 			
-			if(forceUpdate || (lastDrilling != this.drilling) || (lastSpilling != this.spilling)){
+			if(forceUpdate || (lastDrilling != this.drilling) || (lastSpilling != this.spilling) || (Math.abs(getReservoirFlow() - clientFlow) > 0.075*clientFlow)){
 				updateMasterBlock(null, true);
 				setChanged();
 			}
@@ -360,6 +359,11 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 			return true;
 		}
 		return false;
+	}
+	
+	private int getReservoirFlow() {
+		return ReservoirHandler.getIsland(getLevelNonnull(), getBlockPos()) == null || this.worldPosition.getY() < getLevelNonnull().getSeaLevel() ? 10 :
+			   ReservoirIsland.getFlow(ReservoirHandler.getIsland(getLevelNonnull(), getBlockPos()).getPressure(getLevelNonnull(), getBlockPos().getX(), getBlockPos().getZ()));
 	}
 	
 	/** May end up being removed */

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/DerrickTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/DerrickTileEntity.java
@@ -21,6 +21,7 @@ import blusunrize.immersiveengineering.common.util.ResettableCapability;
 import blusunrize.immersiveengineering.common.util.orientation.RelativeBlockFace;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirHandler;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirIsland;
+import flaxbeard.immersivepetroleum.client.ClientProxy;
 import flaxbeard.immersivepetroleum.client.gui.elements.PipeConfig;
 import flaxbeard.immersivepetroleum.client.particle.FluidParticleData;
 import flaxbeard.immersivepetroleum.common.IPContent;
@@ -104,6 +105,7 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 	
 	public final NonNullList<ItemStack> inventory = NonNullList.withSize(1, ItemStack.EMPTY);
 	public boolean drilling, spilling;
+	public int clientFlow;
 	public int timer = 0;
 	
 	private Fluid fluidSpilled = Fluids.EMPTY;
@@ -122,6 +124,7 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 		
 		this.drilling = nbt.getBoolean("drilling");
 		this.spilling = nbt.getBoolean("spilling");
+		this.clientFlow = nbt.getInt("flow");
 		this.timer = nbt.getInt("timer");
 		
 		try{
@@ -151,6 +154,8 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 		nbt.putInt("timer", this.timer);
 		
 		nbt.putString("spillingfluid", this.fluidSpilled.getRegistryName().toString());
+		nbt.putInt("flow", ReservoirHandler.getIsland(getLevelNonnull(), getBlockPos()) == null || this.worldPosition.getY() < getLevelNonnull().getSeaLevel() ? 10 :
+			ReservoirIsland.getFlow(ReservoirHandler.getIsland(getLevelNonnull(), getBlockPos()).getPressure(getLevelNonnull(), getBlockPos().getX(), getBlockPos().getZ())));
 		
 		nbt.put("tank", this.tank.writeToNBT(new CompoundTag()));
 		
@@ -226,7 +231,7 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 		}
 		
 		if(this.spilling){
-			spawnSpillParticles(level, this.worldPosition, this.fluidSpilled, 5, 15.75F);
+			ClientProxy.spawnSpillParticles(level, this.worldPosition, this.fluidSpilled, 5, 15.75F, clientFlow/450f);
 		}
 	}
 	
@@ -536,28 +541,6 @@ public class DerrickTileEntity extends PoweredMultiblockBlockEntity<DerrickTileE
 			well.tappedIslands = list;
 			well.additionalPipes = additionalPipes;
 			well.setChanged();
-		}
-	}
-	
-	@OnlyIn(Dist.CLIENT)
-	public static void spawnSpillParticles(Level world, BlockPos pos, Fluid fluid, int particles, float yOffset){
-		if(fluid == null || fluid == Fluids.EMPTY){
-			return;
-		}
-		
-		for(int i = 0;i < particles;i++){
-			float xa = (world.random.nextFloat() - .5F) / 2F;
-			float ya = 0.75F + (world.random.nextFloat() * 0.25F);
-			float za = (world.random.nextFloat() - .5F) / 2F;
-			
-			float rx = (world.random.nextFloat() - .5F) * 0.5F;
-			float rz = (world.random.nextFloat() - .5F) * 0.5F;
-			
-			double x = (pos.getX() + 0.5) + rx;
-			double y = (pos.getY() + yOffset);
-			double z = (pos.getZ() + 0.5) + rz;
-			
-			world.addParticle(new FluidParticleData(fluid), x, y, z, xa, ya, za);
 		}
 	}
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/WellTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/WellTileEntity.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import flaxbeard.immersivepetroleum.client.ClientProxy;
 import org.apache.commons.lang3.tuple.Pair;
 
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirHandler;
@@ -57,6 +58,7 @@ public class WellTileEntity extends IPTileEntityBase implements IPServerTickable
 	private int spillHeight = -1;
 	
 	boolean spill = false;
+	int clientFlow = 0;
 	public WellTileEntity(BlockPos pWorldPosition, BlockState pBlockState){
 		super(IPTileTypes.WELL.get(), pWorldPosition, pBlockState);
 	}
@@ -64,6 +66,11 @@ public class WellTileEntity extends IPTileEntityBase implements IPServerTickable
 	@Override
 	protected void writeCustom(CompoundTag nbt){
 		nbt.putBoolean("spill", this.spill);
+		nbt.putInt("flow", ReservoirHandler.getIsland(getWorldNonnull(), getBlockPos()) == null ? 0 :
+			ReservoirIsland.getFlow(ReservoirHandler.getIsland(getWorldNonnull(),
+				getBlockPos()).getPressure(getWorldNonnull(),
+				getBlockPos().getX(), getBlockPos().getZ())));
+		
 		nbt.putBoolean("drillingcompleted", this.drillingCompleted);
 		nbt.putBoolean("pastphyiscalpart", this.pastPhysicalPart);
 		
@@ -98,6 +105,7 @@ public class WellTileEntity extends IPTileEntityBase implements IPServerTickable
 	@Override
 	protected void readCustom(CompoundTag nbt){
 		this.spill = nbt.getBoolean("spill");
+		this.clientFlow = nbt.getInt("flow");
 		this.drillingCompleted = nbt.getBoolean("drillingcompleted");
 		this.pastPhysicalPart = nbt.getBoolean("pastphyiscalpart");
 		
@@ -140,7 +148,7 @@ public class WellTileEntity extends IPTileEntityBase implements IPServerTickable
 	public void tickClient(){
 		if(this.spill && this.spillFType != Fluids.EMPTY){
 			BlockPos pPos = this.spillHeight > -1 ? new BlockPos(this.worldPosition.getX(), this.spillHeight, this.worldPosition.getZ()) : this.worldPosition.above();
-			DerrickTileEntity.spawnSpillParticles(this.level, pPos, this.spillFType, 10, -0.25F);
+			ClientProxy.spawnSpillParticles(this.level, pPos, this.spillFType, 10, -0.25F, clientFlow/450f);
 		}
 	}
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/WellTileEntity.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/tileentities/WellTileEntity.java
@@ -148,7 +148,7 @@ public class WellTileEntity extends IPTileEntityBase implements IPServerTickable
 	public void tickClient(){
 		if(this.spill && this.spillFType != Fluids.EMPTY){
 			BlockPos pPos = this.spillHeight > -1 ? new BlockPos(this.worldPosition.getX(), this.spillHeight, this.worldPosition.getZ()) : this.worldPosition.above();
-			ClientProxy.spawnSpillParticles(this.level, pPos, this.spillFType, 10, -0.25F, clientFlow/450f);
+			ClientProxy.spawnSpillParticles(this.level, pPos, this.spillFType, 10, -0.25F, clientFlow);
 		}
 	}
 	


### PR DESCRIPTION
 - Makes flow particle height dependent upon the flow pressure of the reservoir.
     - 800mB/t is approximately equivalent to before, and below sea level flow is very small and equivalent to 10mB/t
     - 1700mB/t is approximately the height of 4/5ths of the tower and very impressive
 - Refactored `DerrickTileEntity#spawnSpillParticles` to make it generic (now in `ClientProxy#spawnSpillParticles`)