### PR TITLE
Region-Based reservoir storage

### DIFF
--- a/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
@@ -20,6 +20,7 @@ import flaxbeard.immersivepetroleum.common.IPContent.Fluids;
 import flaxbeard.immersivepetroleum.common.IPRegisters;
 import flaxbeard.immersivepetroleum.common.IPSaveData;
 import flaxbeard.immersivepetroleum.common.IPToolShaders;
+import flaxbeard.immersivepetroleum.common.ReservoirRegionDataStorage;
 import flaxbeard.immersivepetroleum.common.cfg.IPClientConfig;
 import flaxbeard.immersivepetroleum.common.cfg.IPServerConfig;
 import flaxbeard.immersivepetroleum.common.crafting.RecipeReloadListener;
@@ -158,6 +159,8 @@ public class ImmersivePetroleum{
 		if(!world.isClientSide){
 			IPSaveData worldData = world.getDataStorage().computeIfAbsent(IPSaveData::new, IPSaveData::new, IPSaveData.dataName);
 			IPSaveData.setInstance(worldData);
+			
+			ReservoirRegionDataStorage.init(world.getDataStorage());
 		}
 		
 		ReservoirHandler.recalculateChances();

--- a/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
@@ -158,8 +158,8 @@ public class ImmersivePetroleum{
 	
 	public void worldLoad(WorldEvent.Load event){
 		if(!event.getWorld().isClientSide() && event.getWorld() instanceof ServerLevel world && world.dimension() == Level.OVERWORLD){
-			world.getDataStorage().computeIfAbsent(IPSaveData::new, IPSaveData::new, IPSaveData.dataName);
 			ReservoirRegionDataStorage.init(world.getDataStorage());
+			world.getDataStorage().computeIfAbsent(IPSaveData::new, IPSaveData::new, IPSaveData.dataName);
 		}
 	}
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
@@ -38,7 +38,8 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
-import net.minecraftforge.event.server.ServerStartedEvent;
+import net.minecraftforge.event.server.ServerStartingEvent;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModList;
@@ -88,7 +89,8 @@ public class ImmersivePetroleum{
 		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
 		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::loadComplete);
 		
-		MinecraftForge.EVENT_BUS.addListener(this::serverStarted);
+		MinecraftForge.EVENT_BUS.addListener(this::worldLoad);
+		MinecraftForge.EVENT_BUS.addListener(this::serverStarting);
 		MinecraftForge.EVENT_BUS.addListener(this::registerCommand);
 		MinecraftForge.EVENT_BUS.addListener(this::addReloadListeners);
 		
@@ -154,15 +156,16 @@ public class ImmersivePetroleum{
 		event.addListener(new RecipeReloadListener(event.getServerResources()));
 	}
 	
-	public void serverStarted(ServerStartedEvent event){
-		ServerLevel world = event.getServer().getLevel(Level.OVERWORLD);
-		if(!world.isClientSide){
+	public void worldLoad(WorldEvent.Load event){
+		if(!event.getWorld().isClientSide() && event.getWorld() instanceof ServerLevel world && world.dimension() == Level.OVERWORLD){
 			IPSaveData worldData = world.getDataStorage().computeIfAbsent(IPSaveData::new, IPSaveData::new, IPSaveData.dataName);
 			IPSaveData.setInstance(worldData);
 			
 			ReservoirRegionDataStorage.init(world.getDataStorage());
 		}
-		
+	}
+	
+	public void serverStarting(ServerStartingEvent event){
 		ReservoirHandler.recalculateChances();
 	}
 }

--- a/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
@@ -158,9 +158,7 @@ public class ImmersivePetroleum{
 	
 	public void worldLoad(WorldEvent.Load event){
 		if(!event.getWorld().isClientSide() && event.getWorld() instanceof ServerLevel world && world.dimension() == Level.OVERWORLD){
-			IPSaveData worldData = world.getDataStorage().computeIfAbsent(IPSaveData::new, IPSaveData::new, IPSaveData.dataName);
-			IPSaveData.setInstance(worldData);
-			
+			world.getDataStorage().computeIfAbsent(IPSaveData::new, IPSaveData::new, IPSaveData.dataName);
 			ReservoirRegionDataStorage.init(world.getDataStorage());
 		}
 	}

--- a/src/main/java/flaxbeard/immersivepetroleum/api/crafting/LubricatedHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/api/crafting/LubricatedHandler.java
@@ -118,7 +118,7 @@ public class LubricatedHandler{
 			tag.putInt("x", this.pos.getX());
 			tag.putInt("y", this.pos.getY());
 			tag.putInt("z", this.pos.getZ());
-			tag.putString("world", this.world.getRegistryName().toString());
+			tag.putString("world", this.world.location().toString());
 			tag.putString("lubricant", this.lubricant.getRegistryName().toString());
 			
 			return tag;

--- a/src/main/java/flaxbeard/immersivepetroleum/api/reservoir/ReservoirHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/api/reservoir/ReservoirHandler.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Multimap;
 
 import flaxbeard.immersivepetroleum.ImmersivePetroleum;
 import flaxbeard.immersivepetroleum.common.ReservoirRegionDataStorage;
+import flaxbeard.immersivepetroleum.common.ReservoirRegionDataStorage.RegionData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -90,8 +91,8 @@ public class ReservoirHandler{
 							
 							if(!poly.isEmpty()){
 								int amount = (int) Mth.lerp(random.nextFloat(), reservoir.minSize, reservoir.maxSize);
-								ReservoirIsland island = new ReservoirIsland(poly, reservoir, amount);
 								
+								ReservoirIsland island = new ReservoirIsland(poly, reservoir, amount);
 								storage.addIsland(dimensionKey, island);
 							}
 						}
@@ -138,8 +139,6 @@ public class ReservoirHandler{
 			return null;
 		}
 		
-		// TODO Maybe do this better somehow? It'll do for testing, but not for real-world stuff probably
-		
 		ResourceKey<Level> dimension = world.dimension();
 		Pair<ResourceKey<Level>, ColumnPos> cacheKey = Pair.of(dimension, pos);
 		synchronized(CACHE){
@@ -165,18 +164,6 @@ public class ReservoirHandler{
 		if(world.isClientSide){
 			return null;
 		}
-		
-		/*
-		ResourceKey<Level> dimension = world.dimension();
-		synchronized(RESERVOIR_ISLAND_LIST){
-			for(ReservoirIsland island:RESERVOIR_ISLAND_LIST.get(dimension)){
-				if(island.contains(pos)){
-					// There's no such thing as overlapping islands, so just return what was found directly
-					return island;
-				}
-			}
-		}
-		*/
 		
 		ReservoirIsland island = ReservoirRegionDataStorage.get().getIsland(world, pos);
 		return island;
@@ -257,7 +244,8 @@ public class ReservoirHandler{
 	 * {@link #clearCache()} Must be called after modifying the returned list!
 	 * 
 	 * @return {@link Multimap} of {@link ResourceKey<Level>}<{@link Level}>s to {@link ReservoirIsland}s
-	 * @deprecated
+	 * 
+	 * @deprecated<br>Use {@link RegionData#getReservoirIslandList()} from {@link ReservoirRegionDataStorage#getIsland(Level, BlockPos)}
 	 */
 	@Deprecated(forRemoval = true)
 	public static Multimap<ResourceKey<Level>, ReservoirIsland> getReservoirIslandList(){

--- a/src/main/java/flaxbeard/immersivepetroleum/api/reservoir/ReservoirIsland.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/api/reservoir/ReservoirIsland.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
+import flaxbeard.immersivepetroleum.common.ReservoirRegionDataStorage.RegionData;
 import net.minecraft.ResourceLocationException;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -34,6 +35,8 @@ public class ReservoirIsland{
 	
 	/** "Unsigned 32-Bit" */
 	public static final long MAX_AMOUNT = 0xFFFFFFFFL;
+	
+	private RegionData regionData;
 	
 	@Nonnull
 	private ReservoirType reservoir;
@@ -72,6 +75,11 @@ public class ReservoirIsland{
 		}
 		
 		this.islandAABB = new AxisAlignedIslandBB(minX, minZ, maxX, maxZ);
+	}
+	
+	public void setRegion(RegionData data){
+		if(this.regionData == null)
+			this.regionData = data;
 	}
 	
 	/**
@@ -135,6 +143,12 @@ public class ReservoirIsland{
 		return this.amount <= 0L;
 	}
 	
+	public void setDirty(){
+		if(this.regionData != null){
+			this.regionData.setDirty();
+		}
+	}
+	
 	@Nonnull
 	public ReservoirType getType(){
 		return this.reservoir;
@@ -192,8 +206,7 @@ public class ReservoirIsland{
 		
 		if(fluidAction == FluidAction.EXECUTE){
 			this.amount -= extracted;
-			// TODO Add a reference to the RegionData this ReservoirIsland is assigned to.
-			//IPSaveData.markInstanceAsDirty();
+			setDirty();
 		}
 		
 		return extracted;
@@ -211,8 +224,7 @@ public class ReservoirIsland{
 			int flow = (int) Math.min(getFlow(pressure), this.amount);
 			
 			this.amount -= flow;
-			// TODO Add a reference to the RegionData this ReservoirIsland is assigned to.
-			//IPSaveData.markInstanceAsDirty();
+			setDirty();
 			return flow;
 		}
 		

--- a/src/main/java/flaxbeard/immersivepetroleum/api/reservoir/ReservoirIsland.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/api/reservoir/ReservoirIsland.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
-import flaxbeard.immersivepetroleum.common.IPSaveData;
 import net.minecraft.ResourceLocationException;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -193,7 +192,8 @@ public class ReservoirIsland{
 		
 		if(fluidAction == FluidAction.EXECUTE){
 			this.amount -= extracted;
-			IPSaveData.markInstanceAsDirty();
+			// TODO Add a reference to the RegionData this ReservoirIsland is assigned to.
+			//IPSaveData.markInstanceAsDirty();
 		}
 		
 		return extracted;
@@ -211,7 +211,8 @@ public class ReservoirIsland{
 			int flow = (int) Math.min(getFlow(pressure), this.amount);
 			
 			this.amount -= flow;
-			IPSaveData.markInstanceAsDirty();
+			// TODO Add a reference to the RegionData this ReservoirIsland is assigned to.
+			//IPSaveData.markInstanceAsDirty();
 			return flow;
 		}
 		

--- a/src/main/java/flaxbeard/immersivepetroleum/client/render/debugging/DebugRenderHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/client/render/debugging/DebugRenderHandler.java
@@ -1,7 +1,6 @@
 package flaxbeard.immersivepetroleum.client.render.debugging;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -22,6 +21,8 @@ import flaxbeard.immersivepetroleum.api.reservoir.ReservoirIsland;
 import flaxbeard.immersivepetroleum.client.render.IPRenderTypes;
 import flaxbeard.immersivepetroleum.client.utils.MCUtil;
 import flaxbeard.immersivepetroleum.common.IPContent;
+import flaxbeard.immersivepetroleum.common.ReservoirRegionDataStorage;
+import flaxbeard.immersivepetroleum.common.ReservoirRegionDataStorage.RegionData;
 import flaxbeard.immersivepetroleum.common.blocks.tileentities.AutoLubricatorTileEntity;
 import flaxbeard.immersivepetroleum.common.blocks.tileentities.CokerUnitTileEntity;
 import flaxbeard.immersivepetroleum.common.blocks.tileentities.CokerUnitTileEntity.CokingChamber;
@@ -46,6 +47,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ColumnPos;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
@@ -317,20 +319,32 @@ public class DebugRenderHandler{
 					
 					matrix.pushPose();
 					{
-						synchronized(ReservoirHandler.getReservoirIslandList()){
+						ReservoirRegionDataStorage storage = ReservoirRegionDataStorage.get();
+						final ColumnPos playerRegionPos = storage.toRegionCoords(playerPos);
+						final ResourceKey<Level> dimKey = player.getCommandSenderWorld().dimension();
+						final List<ReservoirIsland> islands = new ArrayList<>();
+						for(int z = -1;z <= 1;z++){
+							for(int x = -1;x <= 1;x++){
+								RegionData rd = storage.getRegionDataFor(new ColumnPos(playerRegionPos.x + x, playerRegionPos.z + z));
+								if(rd != null){
+									synchronized(rd.getReservoirIslandList()){
+										islands.addAll(rd.getReservoirIslandList().get(dimKey));
+									}
+								}
+							}
+						}
+						
+						{
 							MultiBufferSource.BufferSource buffer = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-							
-							Collection<ReservoirIsland> islands = ReservoirHandler.getReservoirIslandList().get(player.getCommandSenderWorld().dimension());
 							
 							if(islands != null && !islands.isEmpty()){
 								float y = 128.0625F;
 								int radius = 128;
 								radius = radius * radius + radius * radius;
 								for(ReservoirIsland island:islands){
-									BlockPos p = new BlockPos(playerPos.getX(), 0, playerPos.getZ());
 									BlockPos center = island.getBoundingBox().getCenter();
 									
-									if(center.distSqr(p) <= radius){
+									if(center.distSqr(playerPos) <= radius){
 										AxisAlignedIslandBB bounds = island.getBoundingBox();
 										matrix.pushPose();
 										{

--- a/src/main/java/flaxbeard/immersivepetroleum/client/render/debugging/DebugRenderHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/client/render/debugging/DebugRenderHandler.java
@@ -325,7 +325,7 @@ public class DebugRenderHandler{
 						final List<ReservoirIsland> islands = new ArrayList<>();
 						for(int z = -1;z <= 1;z++){
 							for(int x = -1;x <= 1;x++){
-								RegionData rd = storage.getRegionDataFor(new ColumnPos(playerRegionPos.x + x, playerRegionPos.z + z));
+								RegionData rd = storage.getRegionData(new ColumnPos(playerRegionPos.x + x, playerRegionPos.z + z));
 								if(rd != null){
 									synchronized(rd.getReservoirIslandList()){
 										islands.addAll(rd.getReservoirIslandList().get(dimKey));

--- a/src/main/java/flaxbeard/immersivepetroleum/common/CommonEventHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/CommonEventHandler.java
@@ -58,14 +58,14 @@ public class CommonEventHandler{
 	@SubscribeEvent
 	public void onSave(WorldEvent.Save event){
 		if(!event.getWorld().isClientSide()){
-			IPSaveData.markInstanceAsDirty();
+			IPSaveData.markDirty();
 		}
 	}
 	
 	@SubscribeEvent
 	public void onUnload(WorldEvent.Unload event){
 		if(!event.getWorld().isClientSide()){
-			IPSaveData.markInstanceAsDirty();
+			IPSaveData.markDirty();
 			ReservoirRegionDataStorage.get().markAllDirty();
 		}
 	}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/CommonEventHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/CommonEventHandler.java
@@ -66,6 +66,7 @@ public class CommonEventHandler{
 	public void onUnload(WorldEvent.Unload event){
 		if(!event.getWorld().isClientSide()){
 			IPSaveData.markInstanceAsDirty();
+			ReservoirRegionDataStorage.get().markAllDirty();
 		}
 	}
 	

--- a/src/main/java/flaxbeard/immersivepetroleum/common/CommonEventHandler.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/CommonEventHandler.java
@@ -9,15 +9,12 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import com.google.common.collect.Multimap;
-
 import blusunrize.immersiveengineering.common.blocks.generic.MultiblockPartBlockEntity;
 import flaxbeard.immersivepetroleum.ImmersivePetroleum;
 import flaxbeard.immersivepetroleum.api.crafting.LubricatedHandler;
 import flaxbeard.immersivepetroleum.api.crafting.LubricatedHandler.ILubricationHandler;
 import flaxbeard.immersivepetroleum.api.crafting.LubricatedHandler.LubricatedTileInfo;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirHandler;
-import flaxbeard.immersivepetroleum.api.reservoir.ReservoirIsland;
 import flaxbeard.immersivepetroleum.common.cfg.IPServerConfig;
 import flaxbeard.immersivepetroleum.common.entity.MotorboatEntity;
 import flaxbeard.immersivepetroleum.common.fluids.NapalmFluid;
@@ -28,7 +25,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.FluidTags;
@@ -75,14 +71,8 @@ public class CommonEventHandler{
 	
 	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public void onServerStopped(ServerStoppedEvent event){
-		Multimap<ResourceKey<Level>, ReservoirIsland> mainList = ReservoirHandler.getReservoirIslandList();
-		synchronized(mainList){
-			ImmersivePetroleum.log.debug("[ReservoirIslands]: Clearing main list.");
-			mainList.clear();
-			
-			ImmersivePetroleum.log.debug("[ReservoirIslands]: Clearing Cache...");
-			ReservoirHandler.clearCache();
-		}
+		ImmersivePetroleum.log.debug("[ReservoirIslands]: Clearing Cache...");
+		ReservoirHandler.clearCache();
 	}
 	
 	@SubscribeEvent

--- a/src/main/java/flaxbeard/immersivepetroleum/common/IPSaveData.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/IPSaveData.java
@@ -21,11 +21,15 @@ import net.minecraft.world.level.saveddata.SavedData;
 public class IPSaveData extends SavedData{
 	public static final String dataName = "ImmersivePetroleum-SaveData";
 	
+	private static IPSaveData INSTANCE;
+	
 	public IPSaveData(){
-		super();
+		INSTANCE = this;
 	}
 	
 	public IPSaveData(CompoundTag nbt){
+		INSTANCE = this;
+		
 		ListTag lubricatedList = nbt.getList("lubricated", Tag.TAG_COMPOUND);
 		LubricatedHandler.lubricatedTiles.clear();
 		for(int i = 0;i < lubricatedList.size();i++){
@@ -89,15 +93,9 @@ public class IPSaveData extends SavedData{
 		return nbt;
 	}
 	
-	private static IPSaveData INSTANCE;
-	
-	public static void markInstanceAsDirty(){
+	public static void markDirty(){
 		if(INSTANCE != null){
 			INSTANCE.setDirty();
 		}
-	}
-	
-	public static void setInstance(IPSaveData in){
-		INSTANCE = in;
 	}
 }

--- a/src/main/java/flaxbeard/immersivepetroleum/common/IPSaveData.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/IPSaveData.java
@@ -5,12 +5,9 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
-import com.google.common.collect.Multimap;
-
 import flaxbeard.immersivepetroleum.ImmersivePetroleum;
 import flaxbeard.immersivepetroleum.api.crafting.LubricatedHandler;
 import flaxbeard.immersivepetroleum.api.crafting.LubricatedHandler.LubricatedTileInfo;
-import flaxbeard.immersivepetroleum.api.reservoir.ReservoirHandler;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirIsland;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
@@ -29,24 +26,6 @@ public class IPSaveData extends SavedData{
 	}
 	
 	public IPSaveData(CompoundTag nbt){
-		ListTag reservoirs = nbt.getList("reservoirs", Tag.TAG_COMPOUND);
-		if(!reservoirs.isEmpty()){
-			Multimap<ResourceKey<Level>, ReservoirIsland> mainList = ReservoirHandler.getReservoirIslandList();
-			synchronized(mainList){
-				ImmersivePetroleum.log.debug("[ReservoirIslands]: Reading...");
-				for(int i = 0;i < reservoirs.size();i++){
-					CompoundTag dim = reservoirs.getCompound(i);
-					ResourceLocation rl = new ResourceLocation(dim.getString("dimension"));
-					ResourceKey<Level> dimType = ResourceKey.create(Registry.DIMENSION_REGISTRY, rl);
-					ListTag islands = dim.getList("islands", Tag.TAG_COMPOUND);
-					
-					List<ReservoirIsland> list = islands.stream().map(inbt -> ReservoirIsland.readFromNBT((CompoundTag) inbt)).filter(o -> o != null).collect(Collectors.toList());
-					mainList.putAll(dimType, list);
-					ImmersivePetroleum.log.debug("[ReservoirIslands]: Read {} islands for dim {}", list.size(), dimType.toString());
-				}
-			}
-		}
-		
 		ListTag lubricatedList = nbt.getList("lubricated", Tag.TAG_COMPOUND);
 		LubricatedHandler.lubricatedTiles.clear();
 		for(int i = 0;i < lubricatedList.size();i++){
@@ -54,11 +33,32 @@ public class IPSaveData extends SavedData{
 			LubricatedTileInfo info = new LubricatedTileInfo(tag);
 			LubricatedHandler.lubricatedTiles.add(info);
 		}
+		
+		// TODO Backwards compability. Remove in 1.19.x!
+		ListTag reservoirs;
+		if(nbt.contains("reservoirs", Tag.TAG_COMPOUND) && (reservoirs = nbt.getList("reservoirs", Tag.TAG_COMPOUND)).isEmpty()){
+			ReservoirRegionDataStorage storage = ReservoirRegionDataStorage.get();
+			
+			ImmersivePetroleum.log.debug("[ReservoirIslands]: Reading...");
+			for(int i = 0;i < reservoirs.size();i++){
+				CompoundTag dim = reservoirs.getCompound(i);
+				ResourceLocation rl = new ResourceLocation(dim.getString("dimension"));
+				ResourceKey<Level> dimType = ResourceKey.create(Registry.DIMENSION_REGISTRY, rl);
+				ListTag islands = dim.getList("islands", Tag.TAG_COMPOUND);
+				
+				List<ReservoirIsland> list = islands.stream().map(inbt -> ReservoirIsland.readFromNBT((CompoundTag) inbt)).filter(o -> o != null).collect(Collectors.toList());
+				list.forEach(island -> {
+					storage.addIsland(dimType, island);
+				});
+				ImmersivePetroleum.log.debug("[ReservoirIslands]: Read {} islands for dim {}", list.size(), dimType.toString());
+			}
+		}
 	}
 	
 	@Override
 	@Nonnull
 	public CompoundTag save(@Nonnull CompoundTag nbt){
+		/*
 		ListTag reservoirs = new ListTag();
 		synchronized(ReservoirHandler.getReservoirIslandList()){
 			for(ResourceKey<Level> dimension:ReservoirHandler.getReservoirIslandList().keySet()){
@@ -75,6 +75,7 @@ public class IPSaveData extends SavedData{
 			}
 		}
 		nbt.put("reservoirs", reservoirs);
+		*/
 		
 		ListTag lubricatedList = new ListTag();
 		for(LubricatedTileInfo info:LubricatedHandler.lubricatedTiles){

--- a/src/main/java/flaxbeard/immersivepetroleum/common/IPSaveData.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/IPSaveData.java
@@ -40,8 +40,8 @@ public class IPSaveData extends SavedData{
 		
 		// TODO Backwards compability. Remove in 1.19.x!
 		ListTag reservoirs;
-		if(nbt.contains("reservoirs", Tag.TAG_COMPOUND) && (reservoirs = nbt.getList("reservoirs", Tag.TAG_COMPOUND)).isEmpty()){
-			ReservoirRegionDataStorage storage = ReservoirRegionDataStorage.get();
+		if(nbt.contains("reservoirs", Tag.TAG_LIST) && !(reservoirs = nbt.getList("reservoirs", Tag.TAG_COMPOUND)).isEmpty()){
+			final ReservoirRegionDataStorage storage = ReservoirRegionDataStorage.get();
 			
 			ImmersivePetroleum.log.debug("[ReservoirIslands]: Reading...");
 			for(int i = 0;i < reservoirs.size();i++){

--- a/src/main/java/flaxbeard/immersivepetroleum/common/ReservoirRegionDataStorage.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/ReservoirRegionDataStorage.java
@@ -38,8 +38,8 @@ import net.minecraft.world.level.storage.DimensionDataStorage;
 public class ReservoirRegionDataStorage extends SavedData{
 	private static final Logger log = LogManager.getLogger(ImmersivePetroleum.MODID + "/RegionDataStorage");
 	
-	private static final String DATA_NAME = "ip-regions";
-	private static final String REGIONDATA_FOLDER = "ipregions\\";
+	private static final String DATA_NAME = "ImmersivePetroleum-ReservoirRegions";
+	private static final String REGIONDATA_FOLDER = "ImmersivePetroleum-ReservoirRegions\\";
 	
 	private static ReservoirRegionDataStorage active_instance;
 	public static ReservoirRegionDataStorage get(){

--- a/src/main/java/flaxbeard/immersivepetroleum/common/ReservoirRegionDataStorage.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/ReservoirRegionDataStorage.java
@@ -1,0 +1,265 @@
+package flaxbeard.immersivepetroleum.common;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import flaxbeard.immersivepetroleum.ImmersivePetroleum;
+import flaxbeard.immersivepetroleum.api.reservoir.ReservoirIsland;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ColumnPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.saveddata.SavedData;
+import net.minecraft.world.level.storage.DimensionDataStorage;
+
+/**
+ * Manager for {@link RegionData}s
+ * 
+ * @author TwistedGate
+ */
+public class ReservoirRegionDataStorage extends SavedData{
+	// FIXME ! Switch all from info to debug later!!
+	private static final Logger log = LogManager.getLogger(ImmersivePetroleum.MODID + "/RegionDataStorage");
+	
+	private static final String DATA_NAME = "ip-regions";
+	private static final String REGIONDATA_FOLDER = "ipregions\\";
+	
+	private static ReservoirRegionDataStorage active_instance;
+	public static ReservoirRegionDataStorage get(){
+		return active_instance;
+	}
+	
+	public static final void init(DimensionDataStorage dimData){
+		active_instance = dimData.computeIfAbsent(t -> load(dimData, t), () -> {
+			log.info("Creating new ReservoirRegionDataStorage instance.");
+			return new ReservoirRegionDataStorage(dimData);
+		}, DATA_NAME);
+	}
+	
+	// -----------------------------------------------------------------------------
+	
+	public static ReservoirRegionDataStorage load(DimensionDataStorage dimData, CompoundTag nbt){
+		ReservoirRegionDataStorage storage = new ReservoirRegionDataStorage(dimData);
+		storage.load(nbt);
+		return storage;
+	}
+	
+	/** Contains existing reservoir-region files */
+	final Map<ColumnPos, RegionData> regions = new HashMap<>();
+	final DimensionDataStorage dimData;
+	public ReservoirRegionDataStorage(DimensionDataStorage dimData){
+		this.dimData = dimData;
+	}
+	
+	@Override
+	public CompoundTag save(CompoundTag nbt){
+		ListTag list = new ListTag();
+		this.regions.forEach((key, entry) -> {
+			CompoundTag tag = new CompoundTag();
+			tag.putInt("x", key.x);
+			tag.putInt("z", key.z);
+			list.add(tag);
+		});
+		nbt.put("regions", list);
+		
+		log.info("Saved regions file.");
+		return nbt;
+	}
+	
+	private void load(CompoundTag nbt){
+		log.info("Started: Loading regions.");
+		ListTag regions = nbt.getList("regions", Tag.TAG_COMPOUND);
+		for(int i = 0;i < regions.size();i++){
+			CompoundTag tag = regions.getCompound(i);
+			int x = tag.getInt("x");
+			int z = tag.getInt("z");
+			
+			ColumnPos rPos = new ColumnPos(x, z);
+			RegionData rData = getOrCreateRegionDataFor(rPos);
+			this.regions.put(rPos, rData);
+		}
+		
+		log.info("Loaded regions file.");
+	}
+	
+	// All of the methods below may not be final and are subject to (heavy) change!
+	
+	public void addIsland(ResourceKey<Level> dimensionKey, ReservoirIsland island){
+		ColumnPos regionPos = toRegionCoords(island.getBoundingBox().getCenter());
+		
+		RegionData regionData = getOrCreateRegionDataFor(regionPos);
+		synchronized(regionData.reservoirlist){
+			if(!regionData.reservoirlist.containsEntry(dimensionKey, island)){
+				regionData.reservoirlist.put(dimensionKey, island);
+				regionData.setDirty();
+			}
+		}
+	}
+	
+	/** May only be called on the server-side. Returns null on client-side. */
+	@Nullable
+	public ReservoirIsland getIsland(Level world, BlockPos pos){
+		return getIsland(world, new ColumnPos(pos));
+	}
+	
+	/** May only be called on the server-side. Returns null on client-side. */
+	@Nullable
+	public ReservoirIsland getIsland(Level world, ColumnPos pos){
+		if(world.isClientSide){
+			return null;
+		}
+		
+		RegionData regionData = getRegionDataFor(toRegionCoords(pos));
+		return regionData != null ? regionData.get(world.dimension(), pos) : null;
+	}
+	
+	public boolean existsAt(final ColumnPos pos){
+		RegionData regionData = getRegionDataFor(toRegionCoords(pos));
+		if(regionData != null){
+			synchronized(regionData.reservoirlist){
+				return regionData.reservoirlist.values().stream().anyMatch(island -> island.contains(pos));
+			}
+		}
+		return false;
+	}
+	
+	/** Utility method */
+	public ColumnPos toRegionCoords(BlockPos pos){
+		// 9 = SectionPos.blockToSectionCoord & ChunkPos.getRegionX
+		return new ColumnPos(pos.getX() >> 9, pos.getZ() >> 9);
+	}
+	
+	/** Utility method */
+	public ColumnPos toRegionCoords(ColumnPos pos){
+		// 9 = SectionPos.blockToSectionCoord & ChunkPos.getRegionX
+		return new ColumnPos(pos.x >> 9, pos.z >> 9);
+	}
+	
+	@Nullable
+	public RegionData getRegionDataFor(BlockPos pos){
+		return getRegionDataFor(toRegionCoords(pos));
+	}
+	
+	@Nullable
+	public RegionData getRegionDataFor(ColumnPos regionPos){
+		RegionData ret = this.regions.getOrDefault(regionPos, null);
+		return ret;
+	}
+	
+	private RegionData getOrCreateRegionDataFor(ColumnPos regionPos){
+		RegionData ret = this.regions.computeIfAbsent(regionPos, p -> {
+			String fn = getRegionFileName(p);
+			RegionData data = this.dimData.computeIfAbsent(t -> new RegionData(p, t), () -> new RegionData(p), fn);
+			setDirty();
+			log.info("Created RegionData for [{}, {}]", regionPos.x, regionPos.z);
+			return data;
+		});
+		return ret;
+	}
+	
+	private String getRegionFileName(ColumnPos regionPos){
+		return REGIONDATA_FOLDER + regionPos.x + "_" + regionPos.z;
+	}
+	
+	// -----------------------------------------------------------------------------
+	
+	/**
+	 * Contains reservoirs within a particular region.
+	 * 
+	 * @author TwistedGate
+	 */
+	public static class RegionData extends SavedData{
+		/** The current region this is assigned to. (Can be used as a sanity-check if need be) */
+		public final ColumnPos regionPos;
+		final Multimap<ResourceKey<Level>, ReservoirIsland> reservoirlist = ArrayListMultimap.create();
+		RegionData(ColumnPos regionPos){
+			this.regionPos = regionPos;
+		}
+		RegionData(ColumnPos regionPos, CompoundTag nbt){
+			this.regionPos = regionPos;
+			load(nbt);
+		}
+		
+		@Override
+		public void save(File pFile){
+			if(!pFile.getParentFile().exists()){
+				pFile.getParentFile().mkdirs();
+			}
+			super.save(pFile);
+		}
+		
+		@Override
+		public CompoundTag save(CompoundTag nbt){
+			ListTag reservoirs = new ListTag();
+			synchronized(this.reservoirlist){
+				for(ResourceKey<Level> dimension:this.reservoirlist.keySet()){
+					CompoundTag dim = new CompoundTag();
+					dim.putString("dimension", dimension.location().toString());
+					
+					ListTag islands = new ListTag();
+					for(ReservoirIsland island:this.reservoirlist.get(dimension)){
+						islands.add(island.writeToNBT());
+					}
+					dim.put("islands", islands);
+					
+					reservoirs.add(dim);
+				}
+			}
+			nbt.put("reservoirs", reservoirs);
+			
+			log.info("RegionData[{}, {}] Saved.", this.regionPos.x, this.regionPos.z);
+			return nbt;
+		}
+		
+		private void load(CompoundTag nbt){
+			ListTag reservoirs = nbt.getList("reservoirs", Tag.TAG_COMPOUND);
+			if(!reservoirs.isEmpty()){
+				synchronized(this.reservoirlist){
+					for(int i = 0;i < reservoirs.size();i++){
+						CompoundTag dim = reservoirs.getCompound(i);
+						ResourceLocation rl = new ResourceLocation(dim.getString("dimension"));
+						ResourceKey<Level> dimType = ResourceKey.create(Registry.DIMENSION_REGISTRY, rl);
+						ListTag islands = dim.getList("islands", Tag.TAG_COMPOUND);
+						
+						List<ReservoirIsland> list = islands.stream().map(inbt -> ReservoirIsland.readFromNBT((CompoundTag) inbt)).filter(o -> o != null).collect(Collectors.toList());
+						this.reservoirlist.putAll(dimType, list);
+					}
+				}
+				log.info("RegionData[{}, {}] Loaded.", this.regionPos.x, this.regionPos.z);
+			}else{
+				log.info("Nothing to load for [{}, {}].", this.regionPos.x, this.regionPos.z);
+			}
+		}
+		
+		public ReservoirIsland get(ResourceKey<Level> dimension, ColumnPos pos){
+			synchronized(this.reservoirlist){
+				for(ReservoirIsland island:this.reservoirlist.get(dimension)){
+					if(island.contains(pos)){
+						return island;
+					}
+				}
+				return null;
+			}
+		}
+		
+		public Multimap<ResourceKey<Level>, ReservoirIsland> getReservoirIslandList(){
+			return this.reservoirlist;
+		}
+	}
+}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/items/DebugItem.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/items/DebugItem.java
@@ -1,14 +1,11 @@
 package flaxbeard.immersivepetroleum.common.items;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
 import javax.annotation.Nonnull;
 
 import org.lwjgl.glfw.GLFW;
-
-import com.google.common.collect.Multimap;
 
 import flaxbeard.immersivepetroleum.ImmersivePetroleum;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirHandler;
@@ -28,14 +25,9 @@ import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.ComponentUtils;
-import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -48,7 +40,6 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.InputEvent;
@@ -112,6 +103,9 @@ public class DebugItem extends IPItemBase{
 			
 			switch(mode){
 				case GENERAL_TEST -> {
+					if(worldIn.isClientSide){
+					}else{
+					}
 					return new InteractionResultHolder<>(InteractionResult.SUCCESS, playerIn.getItemInHand(handIn));
 				}
 				case REFRESH_ALL_IPMODELS -> {
@@ -145,9 +139,8 @@ public class DebugItem extends IPItemBase{
 				case SEEDBASED_RESERVOIR_AREA_TEST -> {
 					BlockPos playerPos = playerIn.blockPosition();
 					
-					if(ReservoirHandler.getIsland(worldIn, playerPos) != null){
-						ReservoirIsland island = ReservoirHandler.getIsland(worldIn, playerPos);
-						
+					ReservoirIsland island;
+					if((island = ReservoirHandler.getIsland(worldIn, playerPos)) != null){
 						int x = playerPos.getX();
 						int z = playerPos.getZ();
 						
@@ -172,6 +165,7 @@ public class DebugItem extends IPItemBase{
 						playerIn.displayClientMessage(new TextComponent(out), true);
 						
 					}else{
+						/*
 						final Multimap<ResourceKey<Level>, ReservoirIsland> islands = ReservoirHandler.getReservoirIslandList();
 						
 						for(ResourceKey<Level> key:islands.keySet()){
@@ -181,6 +175,7 @@ public class DebugItem extends IPItemBase{
 							
 							playerIn.displayClientMessage(new TextComponent(str), false);
 						}
+						*/
 					}
 					
 					return new InteractionResultHolder<>(InteractionResult.SUCCESS, playerIn.getItemInHand(handIn));
@@ -241,40 +236,6 @@ public class DebugItem extends IPItemBase{
 						}
 						
 						player.displayClientMessage(component, false);
-					}
-					
-					synchronized(ReservoirHandler.getReservoirIslandList()){
-						Collection<ReservoirIsland> list = ReservoirHandler.getReservoirIslandList().get(world.dimension());
-						
-						Vec3 playerPos = player.position();
-						double lastDistance = Double.MAX_VALUE;
-						ReservoirIsland nearestIsland = null;
-						for(ReservoirIsland res:list){
-							BlockPos centre = res.getBoundingBox().getCenter();
-							
-							double distance = playerPos.distanceToSqr(centre.getX(), centre.getY(), centre.getZ());
-							if(distance < lastDistance){
-								lastDistance = distance;
-								nearestIsland = res;
-							}
-						}
-						
-						if(nearestIsland != null){
-							BlockPos centre = nearestIsland.getBoundingBox().getCenter();
-							
-							final ClickEvent clickEvent = new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/tp @s " + centre.getX() + " ~ " + centre.getZ());
-							final HoverEvent hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TranslatableComponent("chat.coordinates.tooltip"));
-							
-							TranslatableComponent strOut = new TranslatableComponent("chat.immersivepetroleum.command.reservoir.locate",
-									nearestIsland.getType().name,
-									ComponentUtils.wrapInSquareBrackets(new TextComponent(centre.getX() + " " + centre.getZ())).withStyle((s) -> {
-										return s.withColor(ChatFormatting.GREEN)
-												.withItalic(true)
-												.withClickEvent(clickEvent)
-												.withHoverEvent(hoverEvent);
-									}));
-							player.displayClientMessage(strOut, false);
-						}
 					}
 				}
 				

--- a/src/main/java/flaxbeard/immersivepetroleum/common/items/DebugItem.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/items/DebugItem.java
@@ -16,7 +16,6 @@ import flaxbeard.immersivepetroleum.client.model.IPModel;
 import flaxbeard.immersivepetroleum.client.model.IPModels;
 import flaxbeard.immersivepetroleum.client.utils.MCUtil;
 import flaxbeard.immersivepetroleum.common.IPContent;
-import flaxbeard.immersivepetroleum.common.IPSaveData;
 import flaxbeard.immersivepetroleum.common.entity.MotorboatEntity;
 import flaxbeard.immersivepetroleum.common.network.IPPacketHandler;
 import flaxbeard.immersivepetroleum.common.network.MessageDebugSync;
@@ -148,7 +147,7 @@ public class DebugItem extends IPItemBase{
 						
 						if(playerIn.isShiftKeyDown()){
 							island.setAmount(island.getCapacity());
-							IPSaveData.markInstanceAsDirty();
+							island.setDirty();
 							playerIn.displayClientMessage(new TextComponent("Island Refilled."), true);
 							return new InteractionResultHolder<>(InteractionResult.SUCCESS, playerIn.getItemInHand(handIn));
 						}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/util/commands/IslandCommand.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/util/commands/IslandCommand.java
@@ -78,7 +78,7 @@ public class IslandCommand{
 		final ResourceKey<Level> dimKey = source.getLevel().dimension();
 		for(int rz = -1;rz <= 1;rz++){
 			for(int rx = -1;rx <= 1;rx++){
-				RegionData rd = storage.getRegionDataFor(new ColumnPos(playerRegionPos.x + rx, playerRegionPos.z + rz));
+				RegionData rd = storage.getRegionData(new ColumnPos(playerRegionPos.x + rx, playerRegionPos.z + rz));
 				if(rd != null){
 					synchronized(rd.getReservoirIslandList()){
 						rd.getReservoirIslandList().get(dimKey).forEach(island -> {

--- a/src/main/java/flaxbeard/immersivepetroleum/common/util/commands/IslandCommand.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/util/commands/IslandCommand.java
@@ -20,7 +20,6 @@ import flaxbeard.immersivepetroleum.api.reservoir.AxisAlignedIslandBB;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirHandler;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirIsland;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirType;
-import flaxbeard.immersivepetroleum.common.IPSaveData;
 import flaxbeard.immersivepetroleum.common.ReservoirRegionDataStorage;
 import flaxbeard.immersivepetroleum.common.ReservoirRegionDataStorage.RegionData;
 import flaxbeard.immersivepetroleum.common.util.Utils;
@@ -169,7 +168,7 @@ public class IslandCommand{
 	private static int setReservoirAmount(CommandContext<CommandSourceStack> context, @Nonnull ReservoirIsland island){
 		long amount = context.getArgument("amount", Long.class);
 		island.setAmount(amount);
-		IPSaveData.markInstanceAsDirty();
+		island.setDirty();
 		
 		CommandUtils.sendTranslated(context.getSource(), "chat.immersivepetroleum.command.reservoir.set.amount.success", island.getAmount());
 		return Command.SINGLE_SUCCESS;
@@ -178,7 +177,7 @@ public class IslandCommand{
 	private static int setReservoirCapacity(CommandContext<CommandSourceStack> context, @Nonnull ReservoirIsland island){
 		long capacity = context.getArgument("capacity", Long.class);
 		island.setAmountAndCapacity(capacity, capacity);
-		IPSaveData.markInstanceAsDirty();
+		island.setDirty();
 		
 		CommandUtils.sendTranslated(context.getSource(), "chat.immersivepetroleum.command.reservoir.set.capacity.success", island.getCapacity());
 		return Command.SINGLE_SUCCESS;
@@ -198,7 +197,7 @@ public class IslandCommand{
 		}
 		
 		island.setReservoirType(reservoir);
-		IPSaveData.markInstanceAsDirty();
+		island.setDirty();
 		
 		CommandUtils.sendTranslated(context.getSource(), "chat.immersivepetroleum.command.reservoir.set.type.success", reservoir.name);
 		return Command.SINGLE_SUCCESS;


### PR DESCRIPTION
Splits reservoir storage into seperate, region-based files.
Which should result in a faster save time and reduce lags to practicaly zero.

As can be seen here
![](https://cdn.discordapp.com/attachments/1021774582501347358/1085968011678199909/image.png)
![](https://cdn.discordapp.com/attachments/1021774582501347358/1085968011925672006/image.png)
(Folder and `ip-regions.dat` names are subject to change)

Includes a "backwards-compability/converter" from the old to this new system aswell.

This is in response to #139

---
The old system and the "converter" will be completely gone by 1.19.X