### PR TITLE
Rewritten en_us Manual Entries

### DIFF
--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/asphalt.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/asphalt.txt
@@ -1,4 +1,6 @@
 Asphalt Concrete
-Highway material
-<&asphalt0>Asphalt Concrete, held together by gooey Bitumen, is a darker colored alternative to regular Concrete. It may be produced using the bitumen byproducts of distilling Crude Oil in the <link;immersivepetroleum:distillationtower;§n§oDistillation §n§oTower§r>.<np>
-Asphalt is a high-quality road material, and entities that walk atop it will find their journeys to go quicker - 20% faster on average. Stairs and slabs can be made of asphalt, with the same effects of being a high-quality road material.
+Highway Material
+<&asphalt0>Asphalt concrete is a darker, tarry alternative to regular concrete. Asphalt is produced using bitumen as the binder instead of clay in the concrete, making asphalt concrete a byproduct of the distillation of <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>.<np>
+Asphalt concrete can be cut into stars and slabs using the stonecutter, but cannot be cut into slices as concrete can.
+
+The smooth, durable blacktop produced by asphalt concrete and its cut forms makes an excellent roadway, providing an average 20% speed boost to movement speed.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/asphalt.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/asphalt.txt
@@ -1,6 +1,6 @@
 Asphalt Concrete
 Highway Material
 <&asphalt0>Asphalt concrete is a darker, tarry alternative to regular concrete. Asphalt is produced using bitumen as the binder instead of clay in the concrete, making asphalt concrete a byproduct of the distillation of <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>.<np>
-Asphalt concrete can be cut into stars and slabs using the stonecutter, but cannot be cut into slices as concrete can.
+Asphalt concrete can be cut into stairs and slabs using the stonecutter, but cannot be cut into slices as concrete can.
 
 The smooth, durable blacktop produced by asphalt concrete and its cut forms makes an excellent roadway, providing an average 20% speed boost to movement speed.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/asphalt.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/asphalt.txt
@@ -3,4 +3,4 @@ Highway Material
 <&asphalt0>Asphalt concrete is a darker, tarry alternative to regular concrete. Asphalt is produced using bitumen as the binder instead of clay in the concrete, making asphalt concrete a byproduct of the distillation of <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>.<np>
 Asphalt concrete can be cut into stairs and slabs using the stonecutter, but cannot be cut into slices as concrete can.
 
-The smooth, durable blacktop produced by asphalt concrete and its cut forms makes an excellent roadway, providing an average 20% speed boost to movement speed.
+The smooth, durable blacktop produced by asphalt concrete and its cut forms makes an excellent roadway, providing a 20% boost to movement speed.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/cokerunit.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/cokerunit.txt
@@ -2,14 +2,17 @@ Coker
 Very Sticky Stuff
 <&cokerunit0>The Coker is a massive machine that cracks and carbonizes residual <link;immersivepetroleum:fluids;§n§obitumen§r;bitumen> from distillation into <link;immersivepetroleum:fluids;§n§opetroleum coke§r;petroleum_coke> and <link;immersivepetroleum:fluids;§n§osulfurized §n§odiesel§r;diesel>.
 
-Energy is input through the two high-amperage connectors on the front of the machine, and bitumen and water to the two labeled input ports on the front of the machine. Sulfurized diesel is output from the output port on the front, and petroleum coke from the two hoppers beneath the coking drums.
+Energy is input through the two high-amperage connectors on the front of the machine, and bitumen and water to the two labeled input ports on the front of the machine. Sulfurized diesel is output from the orange port on the front, and petroleum coke from the two hoppers below the coking drums.
 
 Supplying a redstone signal to the control panel will halt the coking process, which can be inverted with the use of the Engineer's Screwdriver.
 
 Due to the heating-cooling cycle of the coking process, the Coker is an energy-intensive machine that requires medium or high voltage infrastructure.
 
 To construct the machine, build it as shown and use the Engineer's Hammer on the concrete block in the center on the side with the redstone engineering block.<np>
-The coking process is as followed: bitumen is loaded into the coking drums. Once the coking drums are full, the drums are brought up to temperature and the bitumen is converted into petroleum coke and sulfurized diesel. When the conversion is complete, the drums are drained of sulfurized diesel, then dumped and flushed with water to cool down for the bitumen to be loaded again.<np>
-The coking drums do not need to be filled up for the coking process to begin, and more bitumen can be input during the first phase of the coking cycle. Once the output and flushing phases have begun, more bitumen cannot be input until the cycle completes.
+The coking process is thus:
+Bitumen is loaded into the coking drums. Once loading has finished, the drums are brought up to temperature and the bitumen is converted into petroleum coke and sulfurized diesel.
 
-Once the currently filling drum is full of bitumen, bitumen will be input to the other coking drum until it is full.
+When the conversion is complete, the drums are drained of sulfurized diesel, then dumped and flushed with water to cool down for bitumen to be loaded again.<np>
+The coking drums do not need to be full for the coking process to begin, and more bitumen can be input during the first phase of the coking cycle. Once the output and flushing phases have begun, more bitumen cannot be input until the cycle completes.
+
+The coking drums operate independently: once the currently loading coking drum is full of bitumen, bitumen will load into the other drum unless the drum is already operating.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/cokerunit.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/cokerunit.txt
@@ -1,13 +1,15 @@
 Coker
-Very sticky stuff
-<&cokerunit0>The Coker is a §overy large§r multiblock structure that further processes Bitumen into Petroleum Coke (Petcoke) and Diesel as a byproduct. It does this by heating the Bitumen up to its thermal cracking temperature. This cracks the heavy, long chain hydrocarbon molecules into Petroleum Coke and Diesel.
+Very Sticky Stuff
+<&cokerunit0>The Coker is a massive machine that cracks and carbonizes residual <link;immersivepetroleum:fluids;§n§obitumen§r;bitumen> from distillation into <link;immersivepetroleum:fluids;§n§opetroleum coke§r;petroleum_coke> and <link;immersivepetroleum:fluids;§n§osulfurized §n§odiesel§r;diesel>.
 
-It is built as shown and formed by using the Engineering's Hammer on the Concrete Block in the Center, on the side with the Redstone Engineering Block.<np>
-Applying a redstone signal to the control panel will halt the machine's process, this behavior can be inverted by use of the Screwdriver.
+Energy is input through the two high-amperage connectors on the front of the machine, and bitumen and water to the two labeled input ports on the front of the machine. Sulfurized diesel is output from the output port on the front, and petroleum coke from the two hoppers beneath the coking drums.
 
-Water is input at the back, the port is marked with a blue dot and Bitumen can be inserted through the hatch in the middle.
-Petcoke is dropped below the chamber chutes.<np>
-The coker uses <config;i;coker_operationcost> Flux/t and 125mB Water per chamber while converting Bitumen into Petcoke.
+Supplying a redstone signal to the control panel will halt the coking process, which can be inverted with the use of the Engineer's Screwdriver.
 
-A chamber does not need to be filled up all the way for the coker to start the process, and more can be added during the first phase.
-If a chamber is filled up all the way it will try to fill the secondary chamber instead.
+Due to the heating-cooling cycle of the coking process, the Coker is an energy-intensive machine that requires medium or high voltage infrastructure.
+
+To construct the machine, build it as shown and use the Engineer's Hammer on the concrete block in the center on the side with the redstone engineering block.<np>
+The coking process is as followed: bitumen is loaded into the coking drums. Once the coking drums are full, the drums are brought up to temperature and the bitumen is converted into petroleum coke and sulfurized diesel. When the conversion is complete, the drums are drained of sulfurized diesel, then dumped and flushed with water to cool down for the bitumen to be loaded again.<np>
+The coking drums do not need to be filled up for the coking process to begin, and more bitumen can be input during the first phase of the coking cycle. Once the output and flushing phases have begun, more bitumen cannot be input until the cycle completes.
+
+Once the currently filling drum is full of bitumen, bitumen will be input to the other coking drum until it is full.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/derrick.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/derrick.txt
@@ -2,18 +2,18 @@ Derrick
 OSHA Nightmare
 <&derrick0>
 The Derrick creates wellheads by drilling reinforced pipes into porous strata containing <link;immersivepetroleum:reservoir;§o§nfluid reservoirs§r> beneath the bedrock.<np>
-The structure is built as shown and formed by using the Engineer's Hammer on the central light engineering block.
+The structure is built as shown and formed by using the Engineer's Hammer on the single light engineering block.
 
-Fluids are input through the central fluid port, and fluid is output from the singular central fluid output port. Drilling pipes must be input by hand.
+Fluids are input through the blue fluid port, and fluid is output from the singular orange fluid output port. Drilling pipes must be input by hand.
 
 Applying a redstone signal to the control panel will halt the drilling process, and can be inverted by use of the Engineer's Screwdriver.<np>
 The derrick's drilling process happens in two stages, and cannot happen below the water line as water will flood the nascent drill hole and erode the walls.
 
-The first phase is the reinforced drilling phase, when the derrick drills above the bedrock and must reinforce the placed fluid pipes with <link;immersiveengineering:mixer;§o§nliquid concrete§r> to stabilize them, placing well pipes.<np>
-Once the derrick has hit bedrock, the second drill phase begins and reinforcement is swapped for a cooling water requirement. The derrick begins drilling through the bedrock to one or more target locations that can be set via its interface, consuming water and fluid pipes to do so.
+The first phase is the reinforced drilling phase, when the derrick drills above the bedrock and must reinforce the placed fluid pipes with <link;immersiveengineering:mixer;§o§nliquid concrete§r> to stabilize them, placing well pipes. If broken, these pipes must be re-drilled.<np>
+Once the derrick has hit bedrock, the second drill phase begins and concrete reinforcement is swapped for cooling water. The derrick begins drilling through the bedrock to one or more target locations that can be set via its interface, consuming water and fluid pipes to do so.
 
-When the well is completed the wellhead is opened and the drilling equipment is forced out of the wel by the fluid pressure from below.
+When the well is completed the wellhead is opened and the drilling equipment is forced out of the well by the fluid pressure from below.
 
-Positive pressure from the well forces fluid to the surface and into the derrick's tank and out to external storage such as the <link;immersivepetroleum:oiltank;§o§nOil Tank§r>. If the derrick's tank is full and has no ability to output, the pressure relief valve will blow and oil will gush from the top of the derrick.
+Positive pressure from the well forces fluid to the surface and into the derrick's tank and out to external storage such as the <link;immersivepetroleum:oiltank;§o§nOil Tank§r>. If the derrick's tank is full and has no ability to output, the pressure relief valve will blow and oil will gush from the top of the derrick and become waste.
 
 Once the positive pressure in the reservoir has dropped to zero, the derrick is no longer needed, and fluid extraction can be moved to a <link;immersivepetroleum:pumpjack;§o§nPumpjack§r>.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/derrick.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/derrick.txt
@@ -1,17 +1,19 @@
 Derrick
 OSHA Nightmare
 <&derrick0>
-The Oil Derrick is a large multiblock structure that drills beneath the bedrock to recover fluid from <link;immersivepetroleum:reservoir;§o§nfluid reservoirs§r>.<np>
-It is built as shown and formed by using the Engineering's Hammer on the Light Engineering Block.
+The Derrick creates wellheads by drilling reinforced pipes into porous strata containing <link;immersivepetroleum:reservoir;§o§nfluid reservoirs§r> beneath the bedrock.<np>
+The structure is built as shown and formed by using the Engineer's Hammer on the central light engineering block.
 
-Applying a redstone signal to the control panel will halt the machine's process, this behavior can be inverted by use of the Screwdriver.
+Fluids are input through the central fluid port, and fluid is output from the singular central fluid output port. Drilling pipes must be input by hand.
 
-The derrick opens up reservoirs for fluid extraction before the <link;immersivepetroleum:pumpjack;§o§nPumpjack§r> can be used to finish off extracting liquid from them. <np>
-The derrick cannot work below the waterline as backpressure from groundwater interferes with well construction.
+Applying a redstone signal to the control panel will halt the drilling process, and can be inverted by use of the Engineer's Screwdriver.<np>
+The derrick's drilling process happens in two stages, and cannot happen below the water line as water will flood the nascent drill hole and erode the walls.
 
-First, the derrick drills down to bedrock, and places encased concrete fluid pipes, consuming <link;immersiveengineering:mixer;§o§nliquid concrete§r> to do so.
+The first phase is the reinforced drilling phase, when the derrick drills above the bedrock and must reinforce the placed fluid pipes with <link;immersiveengineering:mixer;§o§nliquid concrete§r> to stabilize them, placing well pipes.<np>
+Once the derrick has hit bedrock, the second drill phase begins and reinforcement is swapped for a cooling water requirement. The derrick begins drilling through the bedrock to one or more target locations that can be set via its interface, consuming water and fluid pipes to do so.
 
-Once the derrick has hit bedrock, it begins drilling through the bedrock to a target location that can be set via its interface, consuming water and fluid pipes to do so. <np>
-When the well has been dug, fluid pressure from the reservoir is to be positive - fluid is forced out of the derrick and into, depending on space, the derrick tank and out to external storage such as the <link;immersivepetroleum:oiltank;§o§nOil Tank§r>. If the derrick has no ability to output, it will waste and gush fluid out of the top.
+When the well is completed the wellhead is opened and the drilling equipment is forced out of the wel by the fluid pressure from below.
+
+Positive pressure from the well forces fluid to the surface and into the derrick's tank and out to external storage such as the <link;immersivepetroleum:oiltank;§o§nOil Tank§r>. If the derrick's tank is full and has no ability to output, the pressure relief valve will blow and oil will gush from the top of the derrick.
 
 Once the positive pressure in the reservoir has dropped to zero, the derrick is no longer needed, and fluid extraction can be moved to a <link;immersivepetroleum:pumpjack;§o§nPumpjack§r>.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/distillationtower.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/distillationtower.txt
@@ -4,7 +4,7 @@ Environmentally Unfriendly
 It consists of a heating unit and a fractionation column.<np>
 To form the structure, assemble it as shown on the previous page and use the Engineer's Hammer on the redstone engineering block.
 
-Energy is input to the plug at the top of the heating unit, and the fluid to be separated is input to the bottom the unit. Applying a redstone signal to the control panel will halt the machine's process, this behavior can be inverted by use of the Engineer's Screwdriver.
+Energy is input through the plug at the top of the heating unit, and the fluid to be separated is input to the bottom the unit. Applying a redstone signal to the control panel will halt the machine's process, this behavior can be inverted by use of the Engineer's Screwdriver.
 
 The produced fluid mix is output from the side hatch marked with an orange dot; the Bitumen through the front hatch.
 

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/distillationtower.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/distillationtower.txt
@@ -1,34 +1,32 @@
 Distillation Tower
-Environmentally unfriendly
-<&distillationtower0>The Distillation Tower is a large multiblock structure that separates crude oil into a number of byproducts.<np>
-It is built as shown and formed by using the Engineering's Hammer on the Redstone Engineering Block.
+Environmentally Unfriendly
+<&distillationtower0>The Distillation Tower is the energy-intensive workhorse machine of a modern petroleum refinery.
+It consists of a heating unit and a fractionation column.<np>
+To form the structure, assemble it as shown on the previous page and use the Engineer's Hammer on the redstone engineering block.
 
-Applying a redstone signal to the control panel will halt the machine's process, this behavior can be inverted by use of the Screwdriver.
-
-Crude Oil can be input into the Distillation Tower at the back hatch marked with a blue dot, where it will be heated until it separates into a number of layers. This produces a variety of fluids and has a chance to produce Bitumen as a byproduct.
-
-Consuming <config;i;distillationtower_operationcost>IF/t, it converts:
-50mB/t of Crude Oil to:
-|   15mB/t of Naphtha
-|   18mB/t of Kerosene
-|   30mB/t Sulfurized Diesel
-|   12mB/t Lubricant
-|   and some Bitumen.
+Energy is input to the plug at the top of the heating unit, and the fluid to be separated is input to the bottom the unit. Applying a redstone signal to the control panel will halt the machine's process, this behavior can be inverted by use of the Engineer's Screwdriver.
 
 The produced fluid mix is output from the side hatch marked with an orange dot; the Bitumen through the front hatch.
 
-10mB/t of Cracked Naphtha to:
-|   6mB/t Ethylene
-|   2mB/t Propylene
-|   2mB/t Benzene
+The distillation tower can separate the following fluids into their fractions:
 
-12mB/t of Cracked Lubricant to:
-|   6mB/t Kerosene
-|   10mB/t Sulfurized Diesel
+50mB/t of <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude> into
+|   15mB/t of <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha>
+|   18mB/t of <link;immersivepetroleum:fluids;§n§okerosene§r;kerosene>
+|   30mB/t of <link;immersivepetroleum:fluids;§n§osulfurized diesel§r;diesel>
+|   12mB/t of <link;immersivepetroleum:fluids;§n§olubricant§r;lubricant>
+|   0.07/t of <link;immersivepetroleum:fluids;§n§obitumen§r;bitumen>.
 
-10mB/t of Kerosene to:
-|   2mB/t Naphtha
-|   3mB/t Gasoline Additives
-|   5mB/t Sulfurized Diesel
-<np>
-Diesel can be used for <link;diesel_generator;§o§npower §o§nproduction§r>; Lubricant for <link;immersivepetroleum:lubricant;§o§noiling §o§nmachines§r>; Kerosene for <link;diesel_generator;§o§npower §o§nproduction§r>; and Naphtha for <link;immersivepetroleum:portablegenerator;§o§npowering §o§nengines§r> or <link;immersivepetroleum:plastics;§o§nplastics§r>. Bitumen is used to make <link;immersivepetroleum:asphalt;§o§nAsphalt§r> and can be processed to get Petroleum Coke in the <link;immersivepetroleum:cokerunit;§o§nCoker§r>.
+10mB/t of <link;immersivepetroleum:plastics;§n§ocracked naphtha§r;plastics1> into
+|   6mB/t of <link;immersivepetroleum:fluids;§n§oethylene§r;naphtha_derivates>
+|   2mB/t of <link;immersivepetroleum:fluids;§n§opropylene§r;naphtha_derivates>
+|   2mB/t of <link;immersivepetroleum:fluids;§n§obenzene§r;naphtha_derivates>
+
+12mB/t of <link;immersivepetroleum:fluids;§n§ocracked lubricant§r;lubricant> into
+|   6mB/t  of <link;immersivepetroleum:fluids;§n§okerosene§r;kerosene>
+|   10mB/t of <link;immersivepetroleum:fluids;§n§osulfurized diesel§r;diesel>
+
+10mB/t of <link;immersivepetroleum:fluids;§n§okerosene§r;kerosene> into
+|   2mB/t of <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha>
+|   3mB/t of <link;immersivepetroleum:fluids;§n§ogasoline additives§r;gasoline>
+|   5mB/t of <link;immersivepetroleum:fluids;§n§osulfurized diesel§r;diesel>

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/flarestack.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/flarestack.txt
@@ -1,4 +1,7 @@
 Flarestack
-Burns away your problems
-<&flarestack0>This device burns combustible fluids pumped into bottom. Burn rate depends on the applied redstone signal strength, with a maximum burn rate of 250mB/t. This behavior can be inverted by use of the Screwdriver.<np>
-<&flarestack1>Below is a list of fluids which can be burned by the flarestack
+Burns Away Your Problems
+<&flarestack0>The flarestack disposes of any combustible fluid pumped into the input port on the bottom by burning it in a flare jet.
+
+The pilot light of the flarestack is permanently on, and standing on top of it will cause burn damage.<np>
+The flare rate is proportional to the applied redstone signal strength, with a maximum rate of 250mB/t. This behavior can be inverted with the Engineer's Screwdriver.<np>
+Below is a list of fluids which can be burned by the flarestack

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/fluids.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/fluids.txt
@@ -19,7 +19,7 @@ Being a lighter fraction than <link;immersivepetroleum:fluids;§n§odiesel§r;di
 <&naphtha>
 Naphtha is a volatile light fuel usable in <link;immersivepetroleum:portablegenerator;§n§oPortable Generators§r> or <link;immersivepetroleum:speedboat;§n§oMotorboat§r>, and the lightest fraction in <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>.
 
-Its volatility can be controlled via <link;immersiveengineering:refinery;§n§omixing§r> it with gasoline additives to form <link;immersivepetroleum:fluids;§n§ogasoline§r;gasoline>.
+Its volatility can be controlled via mixing it with gasoline additives to form <link;immersivepetroleum:fluids;§n§ogasoline§r;gasoline>.
 
 Naphtha is chemical feedstock for producing plastics, and is often used to produce <link;immersiveengineering:plastic;§n§ophenolic resin§r> from its <link;immersivepetroleum:fluids;§n§oderivates§r;naphtha_derivates>.
 <&bitumen>
@@ -31,9 +31,9 @@ Benzene, propylene, and ethylene are not immediately distillable from crude oil,
 
 Benzene, a liquid, can be used as light fuel, but propylene and ethylene cannot. All three are used as chemical feedstock for <link;immersiveengineering:plastic;§n§ophenolic resin§r>.
 <&gasoline>
-Gasoline is a light fuel suitable for the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r> or <link;immersivepetroleum:speedboat;§n§oMotorboat§r>, and can also be used in <link;immersivepetroleum:fluids;§n§onapalm§r;napalm>.
+Gasoline is a high-quality light fuel suitable for the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r> or <link;immersivepetroleum:speedboat;§n§oMotorboat§r>, and can also be used in <link;immersivepetroleum:fluids;§n§onapalm§r;napalm>.
 
-Gasoline is a mixed, high quality fuel made from <link;immersivepetroleum:fluids;§n§okerosene§r;kerosene> and <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha>, with reduced volatility and a higher efficiency in the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r>.
+ It has reduced volatility and a higher efficiency in the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r>. Gasoline is made from gasoline additives, which are produced from <link;immersivepetroleum:fluids;§n§okerosene§r;kerosene>, and <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha> in the <link;immersiveengineering:refinery;§n§oRefinery§r>.
 <&napalm>
 Napalm is an extremely flammable substance that can be created in the <link;mixer;§n§omixer§r> using <link;immersivepetroleum:fluids;§n§ogasoline§r;gasoline> and three measures of aluminium grit. It has little use other than wanton destruction; when napalm is lit, fire will spread almost immediately over its surface, allowing for rapid deforestation. In addition, it can serve as a very effective fuel for the <link;chemthrower;§n§oChemthrower§r>.
 <&paraffin>

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/fluids.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/fluids.txt
@@ -1,38 +1,46 @@
 Petroleum Products
 At Least It's Not GT5u
 <&crude>
-Crude Oil is a sticky, black substance that seeps from <link;immersivepetroleum:reservoir;§n§oreservoirs§r> in the world. It is the base resource that all other petroleum-based resources take their feedstock from, and is essential to any petrochemical engineer's journey.
+Crude oil is a sticky, black substance that seeps from <link;immersivepetroleum:reservoir;§n§oreservoirs§r> in the world. It is the base resource that all other petroleum-based resources take their feedstock from, and is essential to any petrochemical engineer's journey.
 
 Crude oil can be separated in the <link;immersivepetroleum:distillationtower;§n§oDistillation Tower§r> once it is extracted from reservoirs.
 <&lubricant>
-Lubricant is the heaviest fraction immediately distillable from <link;immersivepetroleum:fluids;§n§oCrude Oil§r;crude>, and is best used to lubricate machines to high efficiency. It can be processed into <link;immersivepetroleum:fluids;§n§oParaffin Wax§r;paraffin>
+Lubricant is the heaviest fraction immediately distillable from <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>, and is best used to lubricate machines to high efficiency. It can be processed into <link;immersivepetroleum:fluids;§n§oparaffin wax§r;paraffin>
 
-It can be burned in the flare stack or cracked into <link;immersivepetroleum:fluids;§n§oDiesel§r;diesel> and <link;immersivepetroleum:fluids;§n§oKerosene§r;kerosene> if such activities are not useful.
+It can be burned in the flare stack or cracked into <link;immersivepetroleum:fluids;§n§odiesel§r;diesel> and <link;immersivepetroleum:fluids;§n§okerosene§r;kerosene> if such activities are not useful.
 <&diesel>
-Diesel and Sulfurized Diesel are the heavyweight fuels of the petrochemical engineer, being able to be used in the <link;immersiveengineering:diesel_generator;§n§oDiesel Generator§r> for bulk power production.
+Diesel and sulfurized diesel are the heavyweight fuels of the petrochemical engineer, being able to be used in the <link;immersiveengineering:diesel_generator;§n§oDiesel Generator§r> for bulk power production.
 
-Sulfurized Diesel can be used for an easy source of sulfur, and is the second-heaviest fraction distillable from <link;immersivepetroleum:fluids;§n§oCrude Oil§r;crude>.
+Sulfurized diesel can be used for an easy source of sulfur, and is the second-heaviest fraction distillable from <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>.
 <&kerosene>
-Kerosene is a medium fuel usable in the <link;immersiveengineering:diesel_generator;§n§oDiesel Generator§r> for bulk power production. It can be separated into its light, medium, and heavy fractions to upgrade <link;immersivepetroleum:fluids;§n§oNaphtha§r;naphtha> into <link;immersivepetroleum:fluids;§n§oGasoline§r;gasoline>.
+Kerosene is a medium fuel usable in the <link;immersiveengineering:diesel_generator;§n§oDiesel Generator§r> for bulk power production. It can be separated into its light, medium, and heavy fractions to upgrade <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha> into <link;immersivepetroleum:fluids;§n§ogasoline§r;gasoline>.
 
-Being a lighter fraction than <link;immersivepetroleum:fluids;§n§oDiesel§r;diesel>, kerosene does not accumulate as much sulfur and does not need to be desulfurized.
+Being a lighter fraction than <link;immersivepetroleum:fluids;§n§odiesel§r;diesel>, kerosene does not accumulate as much sulfur and does not need to be desulfurized.
 <&naphtha>
-Naphtha is a volatile light fuel usable in <link;immersivepetroleum:portablegenerator;§n§oPortable Generators§r> or <link;immersivepetroleum:speedboat;§n§oMotorboat§r>, and the lightest fraction in <link;immersivepetroleum:fluids;§n§oCrude Oil§r;crude>.
+Naphtha is a volatile light fuel usable in <link;immersivepetroleum:portablegenerator;§n§oPortable Generators§r> or <link;immersivepetroleum:speedboat;§n§oMotorboat§r>, and the lightest fraction in <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>.
 
-Its volatility can be controlled via <link;immersiveengineering:refinery;§n§omixing§r> it with gasoline additives to form <link;immersivepetroleum:fluids;§n§oGasoline§r;gasoline>.
+Its volatility can be controlled via <link;immersiveengineering:refinery;§n§omixing§r> it with gasoline additives to form <link;immersivepetroleum:fluids;§n§ogasoline§r;gasoline>.
 
-Naphtha is chemical feedstock for producing plastics, and is often used to produce <link;immersiveengineering:plastic;§n§oPhenolic Resin§r> from its <link;immersivepetroleum:fluids;§n§oderivates§r;naphtha_derivates>.
+Naphtha is chemical feedstock for producing plastics, and is often used to produce <link;immersiveengineering:plastic;§n§ophenolic resin§r> from its <link;immersivepetroleum:fluids;§n§oderivates§r;naphtha_derivates>.
+<&bitumen>
+Bitumen is a dark, sticky solid that can be used as an artificial binder for concrete, making <link;immersivepetroleum:asphalt;§n§oasphalt concrete§r>, or pyrolized to make <link;immersivepetroleum:fluids;§n§opetroleum coke§r;petroleum_coke>.
+
+Bitumen is created from the distillation of <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude> at a slow rate.
 <&naphtha_derivates>
-Benzene, Propylene, and Ethylene are not immediately distillable from crude oil, these lighter feedstocks must be distilled from <link;immersivepetroleum:plastics;§n§ocracked naphtha§r;plastics1>.
+Benzene, propylene, and ethylene are not immediately distillable from crude oil, these lighter feedstocks must be distilled from <link;immersivepetroleum:plastics;§n§ocracked naphtha§r;plastics1>.
 
-Benzene can be used as light fuel, but propylene and ethylene are gasses, and cannot. All three are used as chemical feedstock for <link;immersiveengineering:plastic;§n§oPhenolic Resin§r>.
+Benzene, a liquid, can be used as light fuel, but propylene and ethylene cannot. All three are used as chemical feedstock for <link;immersiveengineering:plastic;§n§ophenolic resin§r>.
 <&gasoline>
-Gasoline is a light fuel suitable for the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r> or <link;immersivepetroleum:speedboat;§n§oMotorboat§r>, and can also be used in <link;immersivepetroleum:fluids;§n§oNapalm§r;napalm>.
+Gasoline is a light fuel suitable for the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r> or <link;immersivepetroleum:speedboat;§n§oMotorboat§r>, and can also be used in <link;immersivepetroleum:fluids;§n§onapalm§r;napalm>.
 
-Gasoline is a mixed, high quality fuel made from <link;immersivepetroleum:fluids;§n§oKerosene§r;kerosene> and <link;immersivepetroleum:fluids;§n§oNaphtha§r;naphtha>, with reduced volatility and a higher efficiency in the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r>.
+Gasoline is a mixed, high quality fuel made from <link;immersivepetroleum:fluids;§n§okerosene§r;kerosene> and <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha>, with reduced volatility and a higher efficiency in the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r>.
 <&napalm>
-Napalm is an extremely flammable substance that can be created in the <link;mixer;§n§oMixer§r> using <link;immersivepetroleum:fluids;§n§oGasoline§r;gasoline> and three measures of Aluminium Grit. It has little use other than wanton destruction; when Napalm is lit, fire will spread almost immediately over its surface, allowing for rapid deforestation. In addition, it can serve as a very effective fuel for the <link;chemthrower;§n§oChemthrower§r>.
+Napalm is an extremely flammable substance that can be created in the <link;mixer;§n§omixer§r> using <link;immersivepetroleum:fluids;§n§ogasoline§r;gasoline> and three measures of aluminium grit. It has little use other than wanton destruction; when napalm is lit, fire will spread almost immediately over its surface, allowing for rapid deforestation. In addition, it can serve as a very effective fuel for the <link;chemthrower;§n§oChemthrower§r>.
 <&paraffin>
 Paraffin wax is a waxy solid that can be used as an artificial beeswax substitute, making candles or waxing copper to stop it from oxidizing.
 
-Paraffin Wax is created from the dewaxing at high pressure of <link;immersivepetroleum:fluids;§n§oLubricant§r;lubricant> at a slow rate.
+Paraffin wax is created from the dewaxing at high pressure of <link;immersivepetroleum:fluids;§n§olubricant§r;lubricant> at a slow rate.
+<&petroleum_coke>
+Petroleum coke is a high-purity allotrope of carbon, equivalent to coal coke. It can be used to make steel, or compressed into <link;immersiveengineering:graphite;§n§oHOP graphite§r>.
+
+Petroleum coke is created from the coking at high temperature of <link;immersivepetroleum:fluids;§n§obitumen§r;bitumen>.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/fluids.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/fluids.txt
@@ -5,7 +5,7 @@ Crude oil is a sticky, black substance that seeps from <link;immersivepetroleum:
 
 Crude oil can be separated in the <link;immersivepetroleum:distillationtower;§n§oDistillation Tower§r> once it is extracted from reservoirs.
 <&lubricant>
-Lubricant is the heaviest fraction immediately distillable from <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>, and is best used to lubricate machines to high efficiency. It can be processed into <link;immersivepetroleum:fluids;§n§oparaffin wax§r;paraffin>
+Lubricant is the heaviest fraction immediately distillable from <link;immersivepetroleum:fluids;§n§ocrude oil§r;crude>, and is best used to increase the working speed of machines via lubrication. It can be processed into <link;immersivepetroleum:fluids;§n§oparaffin wax§r;paraffin>.
 
 It can be burned in the flare stack or cracked into <link;immersivepetroleum:fluids;§n§odiesel§r;diesel> and <link;immersivepetroleum:fluids;§n§okerosene§r;kerosene> if such activities are not useful.
 <&diesel>
@@ -29,7 +29,7 @@ Bitumen is created from the distillation of <link;immersivepetroleum:fluids;§n�
 <&naphtha_derivates>
 Benzene, propylene, and ethylene are not immediately distillable from crude oil, these lighter feedstocks must be distilled from <link;immersivepetroleum:plastics;§n§ocracked naphtha§r;plastics1>.
 
-Benzene, a liquid, can be used as light fuel, but propylene and ethylene cannot. All three are used as chemical feedstock for <link;immersiveengineering:plastic;§n§ophenolic resin§r>.
+Benzene, can be used as light fuel, but propylene and ethylene cannot. All three are used as chemical feedstock for <link;immersiveengineering:plastic;§n§ophenolic resin§r>.
 <&gasoline>
 Gasoline is a high-quality light fuel suitable for the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r> or <link;immersivepetroleum:speedboat;§n§oMotorboat§r>, and can also be used in <link;immersivepetroleum:fluids;§n§onapalm§r;napalm>.
 

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/hydrotreater.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/hydrotreater.txt
@@ -2,9 +2,9 @@ High-Pressure Refinery Unit
 What's A Palladium Catalyst?
 <&hydrotreater0>
 The High-Pressure Refinery Unit heats and combines fluids within its main reaction drum. It is integral to secondary process chains in modern petroleum refining, including cracking and desulfurization.<np>
-Fluctuating power demands from the place the High-Pressure Refinery Unit between LV and MV, with more intensive recipes unable to use LV wiring. Power is input to the port on top of the heating unit.
+Fluctuating power demands from the place the High-Pressure Refinery Unit between LV and MV, with more intensive recipes unable to use LV wiring. Power is input through the port on top of the heating unit.
 
-Fluids are input into the port on the front of the machine, water into the top port beside the control panel. Items are output from the side port beneath the water input, and the reaction product from the port atop the reaction drum.
+Fluids are input through the port on the front of the machine, water into the top port beside the control panel. Items are output from the side port beneath the water input, and the reaction product from the port atop the reaction drum.
 
 It is built as shown and formed by using the Engineer's Hammer on the heavy engineering block in the of the front face.
 

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/hydrotreater.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/hydrotreater.txt
@@ -1,19 +1,13 @@
 High-Pressure Refinery Unit
 What's A Palladium Catalyst?
 <&hydrotreater0>
-The High-Pressure Refinery Unit (HPRU) is a multiblock machine that heats two fluids before combining them together for a fast reaction inside its high-pressure tank.
+The High-Pressure Refinery Unit heats and combines fluids within its main reaction drum. It is integral to secondary process chains in modern petroleum refining, including cracking and desulfurization.<np>
+Fluctuating power demands from the place the High-Pressure Refinery Unit between LV and MV, with more intensive recipes unable to use LV wiring. Power is input to the port on top of the heating unit.
 
-It uses within <config;i;hydrotreater_operationcost_lower> and <config;i;hydrotreater_operationcost_upper> IF/t.
-These conditions make it ideal for three processes: cracking <link;immersivepetroleum:fluids;§n§opetroleum §n§oproducts§r;naphtha> into lighter ones, sulfur recovery from <link;immersivepetroleum:fluids;§n§osulfurized §n§opetroleum §n§oproducts§r;diesel>, and the dewaxing of <link;immersivepetroleum:fluids;§n§olubricant§r;lubricant> to make <link;immersivepetroleum:fluids;§n§oparaffin §n§owax§r;paraffin>.
+Fluids are input into the port on the front of the machine, water into the top port beside the control panel. Items are output from the side port beneath the water input, and the reaction product from the port atop the reaction drum.
 
-It is built as shown and formed by using the Engineering's Hammer on the Heavy Engineering Block in the Center
+It is built as shown and formed by using the Engineer's Hammer on the heavy engineering block in the of the front face.
 
 Applying a redstone signal to the control panel will halt the machine, this behavior can be inverted with the Screwdriver.
 
-§2Sulfurized Diesel§r, §2Lubricant§r or §2Naphtha§r is pumped into the frontal port.
-
-§2Water§r is pumped into the top.
-
-§2Sulfur§r is dumped out the left port.
-
-§2Diesel§r, §2Cracked Lubricant§r or §2Cracked Naphtha§r, depending upon feedstock, is pumped out of the top port on the left side.
+If pneumatically-processed plastic is available, the High-Pressure Refinery Unit can process both <link;immersivepetroleum:fluids;§n§oethylene§r;naphtha_derivates> and <link;immersivepetroleum:fluids;§n§opropylene§r;naphtha_derivates> into molten plastic at a 10x or 20x yield respectively.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/lubricant.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/lubricant.txt
@@ -1,19 +1,17 @@
 Lubrication
-Slip and slide
-Machines have many moving parts, where gears grind past each other or bearings spin on their mounts. While gearboxes can operate without <link;immersivepetroleum:fluids;§n§oLubricant§r;lubricant>, lubrication allows machines to operate faster.
+Slip and Slide
+Lubricated bearings and gearboxes are present in almost every machine, but heavy-duty gearboxes and bearings benefit from their lubricant being regularly flushed and replaced.
 
-Not all machines benefit from lubrication, however. Only machines with high mechanical load do, such as the <link;immersivepetroleum:pumpjack;§n§oPumpjack§r>, <link;excavator;§n§oExcavator§r>, and <link;crusher;§n§oCrusher§r>.
+Machines with high mechanical loads, such as the <link;immersivepetroleum:pumpjack;§n§oPumpjack§r>, <link;excavator;§n§oExcavator§r>, and <link;crusher;§n§oCrusher§r>, can be actively lubricated to increase their speed by 25%.
 
-Lubrication will allow machines to operate at <config;d;autolubricant_speedup>x speed.<np>
-<link;immersivepetroleum:fluids;§n§oPetroleum-Derived Lubricant§r;lubricant> is the most effective lubricant, but <link;squeezer;§n§oPlant Oil§r> can also be used to lubricate machines, at the cost of consuming much more lubricant.
-
-Iron Golems may also be lubricated, healing them and temporarily increasing their speed and strength.
+Iron Golems can be lubricated, temporarily increasing their speed and strength.<np>
+<&lubricant0>
+<link;immersivepetroleum:fluids;§n§oPetroleum lubricant§r;lubricant> is the most effective lubricant, but <link;squeezer;§n§oplant oil§r> can also be used to lubricate machines, at the cost of consuming much more lubricant.
 
 Both Iron Golems and machines will drip spent lubricant while in use, a handy sign of if the machine is lubricated.
 <&lubricant1>The Lubricant Can can be used to manually apply a lubricant to machines. Once the can is full, simply use on a valid block to lubricate it.
 
 A <link;chemthrower;§o§nChemical §o§nThrower§r> can also be used to apply a lubricant to blocks, albeit less efficiently. Simply spray lubricant onto a machine to apply.
 <&lubricant2>
-Manually lubricating machines can be tiring and often frustrating. Once attached to a machine, the Automatic Lubricator will lubricate the machine as long as it is provided with lubricant.
-
-The point where it must be attached is highlighted while holding a lubricator in your hand, and when correctly placed, lubricating pipes will form around the machine.
+The Automatic Lubricator is the solution to the tedium of manual application, lubricating as long as it has fluid.
+The point where it must be attached is highlighted while holding a lubricator. When placed correctly, pipes will form around the machine.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/lubricant.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/lubricant.txt
@@ -2,7 +2,7 @@ Lubrication
 Slip and Slide
 Lubricated bearings and gearboxes are present in almost every machine, but heavy-duty gearboxes and bearings benefit from their lubricant being regularly flushed and replaced.
 
-Machines with high mechanical loads, such as the <link;immersivepetroleum:pumpjack;§n§oPumpjack§r>, <link;excavator;§n§oExcavator§r>, and <link;crusher;§n§oCrusher§r>, can be actively lubricated to increase their speed by 25%.
+Machines with high mechanical loads — such as the <link;immersivepetroleum:pumpjack;§n§oPumpjack§r>, <link;excavator;§n§oExcavator§r>, and <link;crusher;§n§oCrusher§r> — can be actively lubricated to increase their speed by 25%.
 
 Iron Golems can be lubricated, temporarily increasing their speed and strength.<np>
 <&lubricant0>

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/oiltank.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/oiltank.txt
@@ -1,11 +1,12 @@
 Oil Tank
 Bathtub for Gentlemen
 <&oiltank0>
-The Oil Tank is a self-levelling multiblock tank bigger than the normal <link;tank;§o§nFluid Tank§r>, with both side, top, and bottom fluid ports. It can store 1024B of any non-gaseous fluid.<np>
-The Oil Tank will self-level with any non-configured Oil Tanks next to it within a line, so a line of them will all level to the same percentage full.
+The Oil Tank is a self-levelling liquid tank bigger than the normal <link;tank;§o§nFluid Tank§r>, with both side, top, and bottom fluid ports. It can store 1024B of any non-gaseous fluid.<np>
+The Oil Tank will self-level with any non-configured Oil Tanks next to it within a line, bringing each connected tank to an approximately equal liquid level any time fluids are input.
 
-The side fluid ports can be configured with the hammer, while the top and bottom ports cannot. Both the top and bottom port can input, but only the bottom fluid port can output.
+The side fluid ports can be configured with the hammer to either input and output, while the top and bottom ports cannot be configured. Both the top and bottom port can input, but only the bottom fluid port can output.<np>
+Because of its generous capacity and self-leveling, the tank is a good fit for use with the <link;immersivepetroleum:derrick;§o§nDerrick§r> during the gushing phase, to prevent well blowouts due to filled storage and high well pressure.
 
-Because of its generous capacity, the tank is a good fit for use with the <link;immersivepetroleum:derrick;§o§nDerrick§r>, to handle the high production.
+Attaching a comparator to the redstone port of the tank will read the fill of the full tank in a 0-15 metric. Attaching the comparator to one of the layers results in a signal proportional to the height of the comparator.
 
-Attaching a comparator to the redstone port of the tank will read the fill of the full tank in a 0-15 metric. Attaching the comparator to one of the layers results in a signal proportional to the height of the comparator. For example, a comparator attached to the second layer of a tank would not emit any signal until the tank is 1/4 full and have a signal strength of 15 if the tank is half full or more.
+For example, a comparator attached to the second layer of a tank would not emit any signal until the tank is 1/4 full and have a signal strength of 15 if the tank is half full or more.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/plastics.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/plastics.txt
@@ -1,16 +1,16 @@
 Petroleum Plastics
 Does Not Contain 2,3,7,8-TCDD!
 <&plastics0>
-<link;immersiveengineering:plastic;§n§oPhenolic Resin§r> is a chemical marvel for the modern age, but one crucial thing is lacking: it had no petroleum-derived process for its production.
+<link;immersiveengineering:plastic;§n§oPhenolic resin§r> is a chemical marvel for the modern age, but it was missing a petroleum derived process for its production.
 
-Using newly developed thermal cracking systems, this is no longer: phenolic resin can be produced from <link;immersivepetroleum:fluids;§n§oNaphtha§r;naphtha> feedstock using a combination of high temperature techniques to crack it into its constituent alkenes.
+Using newly developed thermal cracking systems, this is no longer: phenolic resin can be produced from <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha> feedstock using a combination of high temperature techniques to crack it into its constituent alkenes.
 <&plastics1>
-Cracked Naphtha is produced in the <link;immersivepetroleum:hydrotreater;§n§oHigh-Pressure Refinery Unit§r>, converting 20mB Naphtha and 5mB of Water to 20mB of Cracked Naphtha.
+The <link;immersivepetroleum:hydrotreater;§n§oHigh-Pressure Refinery Unit§r> is used to crack naphtha, converting 20mB naphtha and 5mB of water to 20mB of cracked naphtha.
 
-Cracked Naphtha can then be <link;immersivepetroleum:distillationtower;§n§odistilled§r> into Benzene, Propylene, and Ethylene; the three alkenes produce portions of the chemical process for <link;immersiveengineering:plastic;§n§oPhenolic Resin§r>.
+Cracked Naphtha can then be <link;immersivepetroleum:distillationtower;§n§odistilled§r> into benzene, propylene, and ethylene; the three alkenes produce portions of the chemical process for <link;immersiveengineering:plastic;§n§ophenolic resin§r>.
 <&plastics2>
-Benzene is a liquid alkene, and can be combined in the <link;immersiveengineering:refinery;§n§oRefinery§r> with Propylene for Phenol, more commonly known as <link;cokeoven;Creosote Oil;outputs>.
+Benzene is a liquid alkene, and can be combined in the <link;immersiveengineering:refinery;§n§oRefinery§r> with propylene for phenol, more commonly known as <link;cokeoven;creosote oil;outputs>.
 
-Ethylene is a gaseous alkene that oxidizable to Acetaldehyde. This process is done using §2Copper Plate§r as catalyst.
+Ethylene is a gaseous alkene that oxidizable to acetaldehyde. This process is done using §2Copper Plate§r as a catalyst.
 
-These two chemical feedstocks are used to produce the polymer resin of <link;immersiveengineering:plastic;§n§oDuroplast§r;duroplast_sheet>.
+These two chemical feedstocks are used to produce the polymer resin of <link;immersiveengineering:plastic;§n§oduroplast§r;duroplast_sheet>.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/portablegenerator.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/portablegenerator.txt
@@ -1,6 +1,9 @@
 Portable Generator
-Gassed up
-<&portablegenerator0>The Portable Generator is a mobile all-in-one power solution. This <link;immersivepetroleum:fluids;§n§olight fuel§r;gasoline>-fueled engine-generator produces up to <config;i;portablegenerator_flux> Flux/t while running, and has an internal power buffer of 100,000 RF.<np>
-The Portable Generator can accept fuel by simply right clicking with a bucket. Gasoline or other light fuel (<link;immersivepetroleum:fluids;§n§oNaphtha, Benzene§r;naphtha>) can also be piped in from above. Power is output directly through LV or MV wires, Connectors are not needed. Applying a redstone signal will halt generation.
+Gassed Up
+<&portablegenerator0>
+Portable Generators are a easily-movable light fuel combustion generator alternate to the heavy, immobile <link;immersiveengineering:diesel_generator;§n§oDiesel Generator§r>. The generator connects to LV and MV power grids directly, and can be picked up with it contents by crouching.<np>
+The Portable Generator produces up to <config;i;portablegenerator_flux> IF/t while burning fuels such as <link;immersivepetroleum:fluids;§n§ogasoline§r;gasoline>, <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha>, or <link;immersivepetroleum:fluids;§n§obenzene§r;naphtha_derivates>, and has an energy buffer of 100,000IF.
 
-Sneaking and right clicking on the generator will pick it up, preserving all stored power and fuel.
+The Portable Generator can accept fuel from buckets and jerrycans, and will accept fuel piped into the fuel input port on top of the generator.
+
+Higher quality fuels will last longer, and a redstone signal will immediately halt the generator with no lost fuel.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/portablegenerator.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/portablegenerator.txt
@@ -1,9 +1,11 @@
 Portable Generator
 Gassed Up
 <&portablegenerator0>
-Portable Generators are a easily-movable light fuel combustion generator alternate to the heavy, immobile <link;immersiveengineering:diesel_generator;§n§oDiesel Generator§r>. The generator connects to LV and MV power grids directly, and can be picked up with it contents by crouching.<np>
+The Portable Generator is an easily-movable, light fuel alternative to the heavy, immobile <link;immersiveengineering:diesel_generator;§n§oDiesel Generator§r>.
+
+The generator connects to LV and MV power grids directly, and can be picked up with it contents by crouching.<np>
 The Portable Generator produces up to <config;i;portablegenerator_flux> IF/t while burning fuels such as <link;immersivepetroleum:fluids;§n§ogasoline§r;gasoline>, <link;immersivepetroleum:fluids;§n§onaphtha§r;naphtha>, or <link;immersivepetroleum:fluids;§n§obenzene§r;naphtha_derivates>, and has an energy buffer of 100,000IF.
 
-The Portable Generator can accept fuel from buckets and jerrycans, and will accept fuel piped into the fuel input port on top of the generator.
+The Portable Generator can accept fuel from buckets, jerrycans, and from a pipe through the input port on top of the generator.
 
 Higher quality fuels will last longer, and a redstone signal will immediately halt the generator with no lost fuel.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/pumpjack.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/pumpjack.txt
@@ -1,13 +1,17 @@
 Pumpjack
-Pump, pump it up
+Pump, Pump It Up
 <&pumpjack0>
-The Pumpjack is a multiblock that pumps liquids from deposits situated underneath bedrock once they have been tapped by the <link;immersivepetroleum:derrick;§o§nDerrick§r>. <np>
-The structure is formed by using the Engineering's Hammer on the Heavy Engineering Block on the second layer.
+The Pumpjack is a machine which pumps liquids from wellheads created by the <link;immersivepetroleum:derrick;§o§nDerrick§r>.
+The structure is formed by using the Engineer's Hammer on the heavy engineering block on the second layer.<np>
+Pumpjacks are the workhorse machine of petroleum extraction, producing a slow but steady amount of liquid from their wells by lifting it through a one-way valve to overcome the lack of well pressure. Wells that still have pressure will overcome the pumpjack's valve and will gush liquid.
 
-Applying a redstone signal to the control panel will halt the machine's process, this behavior can be inverted by use of the Screwdriver.
+To operate, the headpipe connection must be placed directly atop the wellhead so the valve apparatus may be lowered into the wellhead.<np>
+The Pumpjack uses <config;i;pumpjack_consumption> Flux/t to pump liquid at a rate of <config;i;pumpjack_speed> mB/t. Liquids are output through the side ports with orange dots.
 
-The Pumpjack Tower uses <config;i;pumpjack_consumption> Flux/t to pump liquid at a rate of <config;i;pumpjack_speed> mB/t. Liquids are output through the two side ports with orange dots.<np>
-Pumpjack head pipes (the well-block at the very tip) must be placed above a pre-drilled well that is exhausted of pressure from the <link;immersivepetroleum:derrick;§o§nDerrick§r>, and cannot pump straight from the ground.
+The average oil reservoir will take <config;i;pumpjack_days> days to deplete with one pumpjack. Some reservoirs, once the reservoir's hydrostatic pressure is below equilibrium, will replenish fluid that can be extracted by the Pumpjack.
 
-The average Oil deposit will take <config;i;pumpjack_days> days to deplete, though adding more Pumpjacks can speed the process. Some reservoirs, once the reservoir's hydrostatic pressure is below equilibrium, will replenish fluid that can be extracted by the Pumpjack.
+Applying a redstone signal to the control panel will halt the pumpjack motor, this behavior can be inverted by use of the Engineer's Screwdriver.
+
+
+
 

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/speedboat.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/speedboat.txt
@@ -1,15 +1,12 @@
 Motorboat
-Wave rider
-<&speedboat0>You can now travel the seas at high speed with the help of the powerful Motorboat. The Motorboat runs off of <link;immersivepetroleum:fluids;§n§oGasoline§r;gasoline> or other <link;immersivepetroleum:fluids;§n§olight fuels§r;naphtha> which may be added to the fuel tank with a bucket or <link;jerrycan;§n§oJerrycan§r>.
+Wave Rider
+<&speedboat0>The Motorboat is a direct upgrade to the standard wooden boat. The engine in the motorboat runs off the same fuels as the <link;immersivepetroleum:portablegenerator;§n§oPortable Generator§r>, and gives the Motorboat a significant speed boost compared to paddling. Fuel can be added to the tank with any portable fluid canister, such as a bucket or <link;jerrycan;§n§oJerrycan§r>.<np>
+Fuel is consumed while the engine is active at a constant rate whether the Motorboat is moving backwards or forwards. Holding the jump key will increase the speed of the Motorboat, albeit at the cost of higher fuel consumption and increased turn radius.
 
-<np>
-Fuel is consumed while driving the Motorboat forwards or backwards. Holding the jump key will increase the speed of the boat, albeit at the cost of higher fuel consumption and increased turn radius.
-
-Like other devices, the Motorboat can be modified in the <link;workbench;§o§nEngineer's §o§nWorkbench§r>.
-<np>
+Like other devices, the Motorboat can be modified in the <link;workbench;§o§nEngineer's §o§nWorkbench§r>.<np>
 <&speedboat1>
-The §6Expanded Fuel Tank§r allows the Motorboat to hold twice the amount of fuel.
-<&speedboat2>A set of §6Maneuvering Rudders§r gives the Motorboat the ability to change direction much more quickly, drastically improving handling. With this upgrade, the boat's turning radius is impressively lowered.
-<&speedboat3>Navigation through colder climates becomes a trivial task with the §6Icebreaker Bow§r, which allows the Motorboat to ram through ice. In addition to its mobility benefits, the Bow allows the Motorboat to damage monsters that it runs into.
-<&speedboat4>If you seek to explore beyond this realm, or simply wish to make your Motorboat more resistant to the elements, consider installing a §6Reinforced Hull§r. The steel hull grants both increased health and fire resistance to the boat, allowing for navigation of the Nether's vast lava lakes.
-<&speedboat5>Equipping your Motorboat with a pair of §6Emergency Paddles§r means that running out of fuel is no longer the disaster it once was. If the fuel tank on the boat is empty, you can paddle it like a traditional rowboat.
+The §2Expanded Fuel Tank§r allows the Motorboat to hold twice the amount of fuel.
+<&speedboat2>A set of §2Maneuvering Rudders§r gives the Motorboat the ability to change direction much more quickly, drastically improving handling. With this upgrade, the boat's turning radius is impressively lowered.
+<&speedboat3>Navigation through colder climates becomes a trivial task with the §2Icebreaker Bow§r, which allows the Motorboat to ram through ice. In addition to its mobility benefits, the Bow allows the Motorboat to damage monsters that it runs into.
+<&speedboat4>If you seek to explore beyond this realm, or simply wish to make your Motorboat more resistant to the elements, consider installing a §2Reinforced Hull§r. The steel hull grants both increased health and fire resistance to the boat, allowing for navigation of the Nether's vast lava lakes.
+<&speedboat5>Equipping your Motorboat with a pair of §2Emergency Paddles§r means that running out of fuel is no longer the disaster it once was. If the fuel tank on the boat is empty, you can paddle it like a traditional rowboat.

--- a/src/main/resources/assets/immersivepetroleum/manual/en_us/speedboat.txt
+++ b/src/main/resources/assets/immersivepetroleum/manual/en_us/speedboat.txt
@@ -7,6 +7,6 @@ Like other devices, the Motorboat can be modified in the <link;workbench;§o§nE
 <&speedboat1>
 The §2Expanded Fuel Tank§r allows the Motorboat to hold twice the amount of fuel.
 <&speedboat2>A set of §2Maneuvering Rudders§r gives the Motorboat the ability to change direction much more quickly, drastically improving handling. With this upgrade, the boat's turning radius is impressively lowered.
-<&speedboat3>Navigation through colder climates becomes a trivial task with the §2Icebreaker Bow§r, which allows the Motorboat to ram through ice. In addition to its mobility benefits, the Bow allows the Motorboat to damage monsters that it runs into.
+<&speedboat3>Navigation through colder climates becomes a trivial task with the §2Icebreaker Bow§r, which allows the Motorboat to plow through ice. In addition to its mobility benefits, the Icebreaker Bow allows the Motorboat to damage monsters that it runs into.
 <&speedboat4>If you seek to explore beyond this realm, or simply wish to make your Motorboat more resistant to the elements, consider installing a §2Reinforced Hull§r. The steel hull grants both increased health and fire resistance to the boat, allowing for navigation of the Nether's vast lava lakes.
 <&speedboat5>Equipping your Motorboat with a pair of §2Emergency Paddles§r means that running out of fuel is no longer the disaster it once was. If the fuel tank on the boat is empty, you can paddle it like a traditional rowboat.

--- a/src/main/resources/assets/immersivepetroleum/manual/fluids.json
+++ b/src/main/resources/assets/immersivepetroleum/manual/fluids.json
@@ -14,6 +14,9 @@
     "naphtha":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:naphtha_bucket"}]},
+    "bitumen":{"type":"item_display",
+        "type":"item_display",
+        "items":[{"item":"immersivepetroleum:bitumen"}]},
     "naphtha_derivates":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:benzene_bucket"}, {"item":"immersivepetroleum:propylene_bucket"}, {"item":"immersivepetroleum:ethylene_bucket"}]},
@@ -25,5 +28,8 @@
         "items":[{"item":"immersivepetroleum:napalm_bucket"}]},
     "paraffin":{"type":"item_display",
         "type":"item_display",
-        "items":[{"item":"immersivepetroleum:paraffin_wax"}]}
+        "items":[{"item":"immersivepetroleum:paraffin_wax"}]},
+    "petroleum_coke":{"type":"item_display",
+        "type":"item_display",
+        "items":[{"item":"immersivepetroleum:petcoke"}]}
 }

--- a/src/main/resources/assets/immersivepetroleum/manual/fluids.json
+++ b/src/main/resources/assets/immersivepetroleum/manual/fluids.json
@@ -14,22 +14,22 @@
     "naphtha":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:naphtha_bucket"}]},
-    "bitumen":{"type":"item_display",
+    "bitumen":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:bitumen"}]},
     "naphtha_derivates":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:benzene_bucket"}, {"item":"immersivepetroleum:propylene_bucket"}, {"item":"immersivepetroleum:ethylene_bucket"}]},
-    "gasoline":{"type":"item_display",
+    "gasoline":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:gasoline_bucket"}, {"item":"immersivepetroleum:gasoline_additives_bucket"}]},
-    "napalm":{"type":"item_display",
+    "napalm":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:napalm_bucket"}]},
-    "paraffin":{"type":"item_display",
+    "paraffin":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:paraffin_wax"}]},
-    "petroleum_coke":{"type":"item_display",
+    "petroleum_coke":{
         "type":"item_display",
         "items":[{"item":"immersivepetroleum:petcoke"}]}
 }

--- a/src/main/resources/assets/immersivepetroleum/manual/fluids.json
+++ b/src/main/resources/assets/immersivepetroleum/manual/fluids.json
@@ -28,8 +28,8 @@
         "items":[{"item":"immersivepetroleum:napalm_bucket"}]},
     "paraffin":{
         "type":"item_display",
-        "items":[{"item":"immersivepetroleum:paraffin_wax"}]},
+        "items":[{"item":"immersivepetroleum:paraffin_wax"}, {"item":"immersivepetroleum:paraffin_wax_block"}]},
     "petroleum_coke":{
         "type":"item_display",
-        "items":[{"item":"immersivepetroleum:petcoke"}]}
+        "items":[{"item":"immersivepetroleum:petcoke"}, {"item":"immersivepetroleum:petcoke_block"}]}
 }

--- a/src/main/resources/assets/immersivepetroleum/manual/lubricant.json
+++ b/src/main/resources/assets/immersivepetroleum/manual/lubricant.json
@@ -1,4 +1,8 @@
 {
+	"lubricant0":{
+			"type":"item_display",
+			"items":[{"item":"immersivepetroleum:lubricant_bucket"}, {"item":"immersiveengineering:plantoil_bucket"}]
+	},
 	"lubricant1":{
 		"type": "crafting",
 		"recipe": "immersivepetroleum:oil_can"

--- a/src/main/resources/assets/immersivepetroleum/manual/plastics.json
+++ b/src/main/resources/assets/immersivepetroleum/manual/plastics.json
@@ -1,7 +1,7 @@
 {
 	"plastics0":{
 		"type":"item_display",
-		"items":[{"item":"immersivepetroleum:naphtha_bucket"}]},
+		"items":[{"item":"immersiveengineering:phenolic_resin_bucket"}, {"item":"immersiveengineering:plate_duroplast"}, {"item":"immersiveengineering:duroplast"}]},
 	"plastics1":{
 		"type":"item_display",
 		"items":[{"item":"immersivepetroleum:naphtha_cracked_bucket"}]},


### PR DESCRIPTION
Rewrites every manual entry except for the projector for en_us to make them clearer & fix spelling mistakes.
Also adds two new pages to the petroleum products tab to include petroleum coke and bitumen.